### PR TITLE
docker based ci + first `slang` pipeline

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM ubuntu:22.04
 
-RUN apt update && apt upgrade -y && apt install -y curl python3 build-essential git cmake python3-pip wget
+RUN apt update && apt upgrade -y && apt install -y curl python3 build-essential git cmake python3-pip wget unzip
 
 # ARG RISCV_GCC_VERSION=8.3.0-2020.04.0
 # risvc-gnu-compiler


### PR DESCRIPTION
This adds a docker-based ci and a first `bender` + `morty` + `slang` check pipeline. This pipeline is not yet working due to a pickling error in morty but I am looking into that.