### PR TITLE
ci: Improve workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ name: build
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    types: [opened, reopened]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,7 @@
 
 name: build
 
-on:
-  push:
-  pull_request:
-    types: [opened, reopened]
-  workflow_dispatch:
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
 

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -6,12 +6,7 @@
 
 name: gitlab-ci
 
-on:
-  push:
-  delete:
-  pull_request:
-    types: [opened, reopened]
-  workflow_dispatch:
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
 
@@ -48,8 +43,11 @@ jobs:
         pip install -r requirements.txt
     -
       name: Poll results
-      run: .github/gitlab-ci.py
+      # Pull request SHAs point to a merged commit that is not mirrored
+      run: |
+        export SHA=${{ github.sha }}
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then export SHA=${{ github.event.pull_request.head.sha }}; fi
+        .github/gitlab-ci.py
       env:
         TOKEN: ${{ secrets.GITLAB_TOKEN }}
-        SHA: ${{ github.sha }}
         PIPELINES: "https://iis-git.ee.ethz.ch/api/v4/projects/3478/pipelines"

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -6,7 +6,12 @@
 
 name: gitlab-ci
 
-on: [push, delete]
+on:
+  push:
+  delete:
+  pull_request:
+    types: [opened, reopened]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ name: lint
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    types: [opened, reopened]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,7 @@
 
 name: lint
 
-on:
-  push:
-  pull_request:
-    types: [opened, reopened]
-  workflow_dispatch:
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
 


### PR DESCRIPTION
* Add `pull_request` and `workflow_dispatch` triggers on our CI except docker tasks.
* Run on all branches, not just `main`.
* The `gitlab-ci` workflow will no longer trigger on `delete`.