### PR TITLE
sw: Add DEBUG mode to enable/disable printf at compile time

### DIFF
--- a/sw/include/util.h
+++ b/sw/include/util.h
@@ -13,3 +13,10 @@
 #define CHECK_ELSE_TRAP(call, code) \
     if ((call) != (code)) \
         asm volatile("addi a0, x0, -3\n j _exit" ::: "a0");
+
+#ifdef DEBUG
+#define PRINTF(fmt, ...) printf_("%s:%d: " fmt, __func__, __LINE__, ##__VA_ARGS__);
+#else
+#define PRINTF(...) ((void)0)
+#endif
+

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -20,6 +20,8 @@ REGGEN        ?= $(PYTHON3) $(shell $(BENDER) path register_interface)/vendor/lo
 
 RISCV_FLAGS   ?= -march=rv64gc_zifencei -mabi=lp64d -O2 -Wall -static -ffunction-sections -fdata-sections -frandom-seed=cheshire
 RISCV_CCFLAGS ?= $(RISCV_FLAGS) -ggdb -mcmodel=medany -mexplicit-relocs -fno-builtin -fverbose-asm -pipe
+# Add here application-specific flags
+RISCV_APP_CCFLAGS += $(RISCV_CCFLAGS) -DDEBUG
 RISCV_LDFLAGS ?= $(RISCV_FLAGS) -nostartfiles -Wl,--gc-sections
 
 TOP_DIR       ?= $(shell git rev-parse --show-toplevel)
@@ -104,10 +106,10 @@ sw-headers: $(GEN_HDRS)
 
 # All objects require up-to-date patches and headers
 %.o: %.c $(SW_DIR)/deps/.patched $(GEN_HDRS)
-	$(RISCV_CC) $(INCLUDES) $(RISCV_CCFLAGS) -c $< -o $@
+	$(RISCV_CC) $(INCLUDES) $(RISCV_APP_CCFLAGS) -c $< -o $@
 
 %.o: %.S $(SW_DIR)/deps/.patched $(GEN_HDRS)
-	$(RISCV_CC) $(INCLUDES) $(RISCV_CCFLAGS) -c $< -o $@
+	$(RISCV_CC) $(INCLUDES) $(RISCV_APP_CCFLAGS) -c $< -o $@
 
 define ld_elf_rule
 .PRECIOUS: %.$(1).elf

--- a/sw/tests/addressing_test.c
+++ b/sw/tests/addressing_test.c
@@ -9,6 +9,7 @@
 #include "printf.h"
 #include "trap.h"
 #include "uart.h"
+#include "util.h"
 
 char uart_initialized = 0;
 
@@ -22,17 +23,17 @@ void test_64_bit_access(void *addr, int length) {
     unsigned long int test_p = 0xAAAAAAAAAAAAAAAA;
     unsigned long int test_n = 0x5555555555555555;
 
-    printf_("\tTesting 64 bit accesses\r\n");
+    PRINTF("\tTesting 64 bit accesses\r\n");
     for (unsigned long int i = 0; i < length / 8; i++) {
         word[i] = test_p;
         if (word[i] != test_p) {
-            printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_p, word[i]);
+            PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_p, word[i]);
             errors++;
         }
 
         word[i] = test_n;
         if (word[i] != test_n) {
-            printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_n, word[i]);
+            PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_n, word[i]);
             errors++;
         }
     }
@@ -43,17 +44,17 @@ void test_32_bit_access(void *addr, int length) {
     unsigned int test_p = 0xAAAAAAAA;
     unsigned int test_n = 0x55555555;
 
-    printf_("\tTesting 32 bit accesses\r\n");
+    PRINTF("\tTesting 32 bit accesses\r\n");
     for (unsigned long int i = 0; i < length / 4; i++) {
         word[i] = test_p;
         if (word[i] != test_p) {
-            printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_p, word[i]);
+            PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_p, word[i]);
             errors++;
         }
 
         word[i] = test_n;
         if (word[i] != test_n) {
-            printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_n, word[i]);
+            PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_n, word[i]);
             errors++;
         }
     }
@@ -64,17 +65,17 @@ void test_16_bit_access(void *addr, int length) {
     unsigned short test_p = 0xAAAA;
     unsigned short test_n = 0x5555;
 
-    printf_("\tTesting 16 bit accesses\r\n");
+    PRINTF("\tTesting 16 bit accesses\r\n");
     for (unsigned long int i = 0; i < length / 2; i++) {
         word[i] = test_p;
         if (word[i] != test_p) {
-            printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_p, word[i]);
+            PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_p, word[i]);
             errors++;
         }
 
         word[i] = test_n;
         if (word[i] != test_n) {
-            printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_n, word[i]);
+            PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_n, word[i]);
             errors++;
         }
     }
@@ -85,17 +86,17 @@ void test_8_bit_access(void *addr, int length) {
     unsigned char test_p = 0xAA;
     unsigned char test_n = 0x55;
 
-    printf_("\tTesting 8 bit accesses\r\n");
+    PRINTF("\tTesting 8 bit accesses\r\n");
     for (unsigned long int i = 0; i < length; i++) {
         word[i] = test_p;
         if (word[i] != test_p) {
-            printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_p, word[i]);
+            PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_p, word[i]);
             errors++;
         }
 
         word[i] = test_n;
         if (word[i] != test_n) {
-            printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_n, word[i]);
+            PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], test_n, word[i]);
             errors++;
         }
     }
@@ -109,7 +110,7 @@ void test_64_32_subaccess(void *addr, int length) {
     unsigned long int merged = 0;
     int subwords = 64 / 32;
 
-    printf_("\tTesting clean 32 bit sub-accesses\r\n");
+    PRINTF("\tTesting clean 32 bit sub-accesses\r\n");
     for (unsigned long int i = 0; i < length / 8; i++) {
         for (int j = 0; j < subwords; j++) {
             word[i] = test_p;
@@ -125,7 +126,7 @@ void test_64_32_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
 
@@ -142,7 +143,7 @@ void test_64_32_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
         }
@@ -157,7 +158,7 @@ void test_64_16_subaccess(void *addr, int length) {
     unsigned long int merged = 0;
     int subwords = 64 / 16;
 
-    printf_("\tTesting clean 16 bit sub-accesses\r\n");
+    PRINTF("\tTesting clean 16 bit sub-accesses\r\n");
     for (unsigned long int i = 0; i < length / 8; i++) {
         for (int j = 0; j < subwords; j++) {
             word[i] = test_p;
@@ -173,7 +174,7 @@ void test_64_16_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
 
@@ -190,7 +191,7 @@ void test_64_16_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
         }
@@ -205,7 +206,7 @@ void test_64_8_subaccess(void *addr, int length) {
     unsigned long int merged = 0;
     int subwords = 64 / 8;
 
-    printf_("\tTesting clean 8 bit sub-accesses\r\n");
+    PRINTF("\tTesting clean 8 bit sub-accesses\r\n");
     for (unsigned long int i = 0; i < length / 8; i++) {
         for (int j = 0; j < subwords; j++) {
             word[i] = test_p;
@@ -221,7 +222,7 @@ void test_64_8_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
 
@@ -238,7 +239,7 @@ void test_64_8_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
         }
@@ -253,7 +254,7 @@ void test_32_16_subaccess(void *addr, int length) {
     unsigned int merged = 0;
     int subwords = 32 / 16;
 
-    printf_("\tTesting clean 16 bit sub-accesses\r\n");
+    PRINTF("\tTesting clean 16 bit sub-accesses\r\n");
     for (unsigned long int i = 0; i < length / 4; i++) {
         for (int j = 0; j < subwords; j++) {
             word[i] = test_p;
@@ -269,7 +270,7 @@ void test_32_16_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
 
@@ -286,7 +287,7 @@ void test_32_16_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
         }
@@ -301,7 +302,7 @@ void test_32_8_subaccess(void *addr, int length) {
     unsigned int merged = 0;
     int subwords = 32 / 8;
 
-    printf_("\tTesting clean 8 bit sub-accesses\r\n");
+    PRINTF("\tTesting clean 8 bit sub-accesses\r\n");
     for (unsigned long int i = 0; i < length / 4; i++) {
         for (int j = 0; j < subwords; j++) {
             word[i] = test_p;
@@ -317,7 +318,7 @@ void test_32_8_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
 
@@ -334,7 +335,7 @@ void test_32_8_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
         }
@@ -349,7 +350,7 @@ void test_16_8_subaccess(void *addr, int length) {
     unsigned short merged = 0;
     int subwords = 16 / 8;
 
-    printf_("\tTesting clean 8 bit sub-accesses\r\n");
+    PRINTF("\tTesting clean 8 bit sub-accesses\r\n");
     for (unsigned long int i = 0; i < length / 2; i++) {
         for (int j = 0; j < subwords; j++) {
             word[i] = test_p;
@@ -365,7 +366,7 @@ void test_16_8_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
 
@@ -382,7 +383,7 @@ void test_16_8_subaccess(void *addr, int length) {
             }
 
             if (word[i] != merged) {
-                printf_("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
+                PRINTF("\t!!! Address: 0x%lx, Expected: 0x%lx, Got: 0x%lx\r\n", &word[i], merged, word[i]);
                 errors++;
             }
         }
@@ -391,33 +392,33 @@ void test_16_8_subaccess(void *addr, int length) {
 
 void read_64_bit_access(void *addr, int length) {
     volatile unsigned long int *word = (unsigned long int *)addr;
-    printf_("Dumping data in 64 bit words\r\n");
+    PRINTF("Dumping data in 64 bit words\r\n");
     for (unsigned long int i = 0; i < length / 8; i++) {
-        printf_("\tAddress: 0x%lx, Data: 0x%lx\r\n", &word[i], word[i]);
+        PRINTF("\tAddress: 0x%lx, Data: 0x%lx\r\n", &word[i], word[i]);
     }
 }
 
 void read_32_bit_access(void *addr, int length) {
     volatile unsigned int *word = (unsigned int *)addr;
-    printf_("Dumping data in 32 bit words\r\n");
+    PRINTF("Dumping data in 32 bit words\r\n");
     for (unsigned long int i = 0; i < length / 4; i++) {
-        printf_("\tAddress: 0x%lx, Data: 0x%x\r\n", &word[i], word[i]);
+        PRINTF("\tAddress: 0x%lx, Data: 0x%x\r\n", &word[i], word[i]);
     }
 }
 
 void read_16_bit_access(void *addr, int length) {
     volatile unsigned short *word = (unsigned short *)addr;
-    printf_("Dumping data in 16 bit words\r\n");
+    PRINTF("Dumping data in 16 bit words\r\n");
     for (unsigned long int i = 0; i < length / 2; i++) {
-        printf_("\tAddress: 0x%lx, Data: 0x%x\r\n", &word[i], word[i]);
+        PRINTF("\tAddress: 0x%lx, Data: 0x%x\r\n", &word[i], word[i]);
     }
 }
 
 void read_8_bit_access(void *addr, int length) {
     volatile unsigned char *word = (unsigned char *)addr;
-    printf_("Dumping data in 8 bit words\r\n");
+    PRINTF("Dumping data in 8 bit words\r\n");
     for (unsigned long int i = 0; i < length; i++) {
-        printf_("\tAddress: 0x%lx, Data: 0x%x\r\n", &word[i], word[i]);
+        PRINTF("\tAddress: 0x%lx, Data: 0x%x\r\n", &word[i], word[i]);
     }
 }
 
@@ -425,7 +426,7 @@ int main(void) {
     // init_uart(200000000, 115200);
     init_uart(50000000, 115200);
     uart_initialized = 1;
-    printf_("Testing addressing throughout the system\r\n");
+    PRINTF("Testing addressing throughout the system\r\n");
 
     // Disable D-Cache
     asm volatile("addi t0, x0, 1\n   \
@@ -436,7 +437,7 @@ int main(void) {
 
     // Start the tedious testing
     for (unsigned int i = 0; i < test_addresses_length; i++) {
-        printf_("\r\nTesting 0x%lx(%d)\r\n", ta[i].addr, ta[i].length);
+        PRINTF("\r\nTesting 0x%lx(%d)\r\n", ta[i].addr, ta[i].length);
 
         // Read-Write access => We can actually perform tests
         if (ta[i].access == 3) {
@@ -493,14 +494,14 @@ int main(void) {
                 read_8_bit_access(ta[i].addr, ta[i].length);
             }
         } else {
-            printf_("\tCannot test with access rights %d\r\n", ta[i].access);
+            PRINTF("\tCannot test with access rights %d\r\n", ta[i].access);
         }
         printf("---- %u Errors ----\r\n\r\n", errors);
         total_errors += errors;
         errors = 0;
     }
 
-    printf_("Finished test with %u errors.\r\n", total_errors);
+    PRINTF("Finished test with %u errors.\r\n", total_errors);
 
     return total_errors;
 }

--- a/sw/tests/axi_llc_test.c
+++ b/sw/tests/axi_llc_test.c
@@ -9,6 +9,7 @@
 #include "printf.h"
 #include "trap.h"
 #include "uart.h"
+#include "util.h"
 
 char uart_initialized = 0;
 
@@ -17,18 +18,18 @@ extern void *__base_axi_llc;
 void __attribute__((aligned(4))) trap_vector(void) { test_trap_vector(&uart_initialized); }
 
 void init_llc(void *base) {
-    printf("[axi_llc] AXI LLC Version   :       0x%lx\r\n", axi_llc_reg32_get_version(base));
-    printf("[axi_llc] Set Associativity :       %d\r\n", axi_llc_reg32_get_set_asso(base));
-    printf("[axi_llc] Num Blocks        :       %d\r\n", axi_llc_reg32_get_num_blocks(base));
-    printf("[axi_llc] Num Lines         :       %d\r\n", axi_llc_reg32_get_num_lines(base));
-    printf("[axi_llc] BIST Outcome      :       %d\r\n", axi_llc_reg32_get_bist_out(base));
+    PRINTF("[axi_llc] AXI LLC Version   :       0x%lx\r\n", axi_llc_reg32_get_version(base));
+    PRINTF("[axi_llc] Set Associativity :       %d\r\n", axi_llc_reg32_get_set_asso(base));
+    PRINTF("[axi_llc] Num Blocks        :       %d\r\n", axi_llc_reg32_get_num_blocks(base));
+    PRINTF("[axi_llc] Num Lines         :       %d\r\n", axi_llc_reg32_get_num_lines(base));
+    PRINTF("[axi_llc] BIST Outcome      :       %d\r\n", axi_llc_reg32_get_bist_out(base));
 
     axi_llc_reg32_all_spm(base);
 }
 
 int main(void) {
-    // init_uart(200000000, 115200);
-    init_uart(50000000, 115200);
+    init_uart(200000000, 115200);
+    //init_uart(50000000, 115200);
 
     uart_initialized = 1;
 

--- a/sw/tests/i2c_fpga_test.c
+++ b/sw/tests/i2c_fpga_test.c
@@ -101,7 +101,7 @@ int xilinx_ina219_read_reg(dif_i2c_t *i2c, uint8_t address, uint8_t reg) {
 int main(void) {
     init_uart(CORE_FREQ_HZ, 115200);
     uart_initialized = 1;
-    printf("Testing I2C\r\n");
+    PRINTF("Testing I2C\r\n");
 
     // Obtain handle to I2C
     // mmio_region_t i2c_base = mmio_region_from_addr((uintptr_t) &__base_i2c);
@@ -127,12 +127,12 @@ int main(void) {
     // We do *not* set up any interrupts; traps of any kind should be fatal
     CHECK_ELSE_TRAP(dif_i2c_host_set_enabled(&i2c, kDifI2cToggleEnabled), kDifI2cOk)
 
-    printf("Configured I2C in host mode with a SCL period of %u ns\r\n", timing_config.scl_period_nanos);
+    PRINTF("Configured I2C in host mode with a SCL period of %u ns\r\n", timing_config.scl_period_nanos);
 
     // Init all the INA219s
     for (int i = 0; i < 6; i++) {
         xilinx_ina219_init(&i2c, ina219_addresses[i]);
-        printf("Initialized INA219 for %s\r\n", ina219_rails[i]);
+        PRINTF("Initialized INA219 for %s\r\n", ina219_rails[i]);
     }
 
     while (true) {
@@ -152,16 +152,16 @@ int main(void) {
 
             current = current >> 1;
 
-            printf("%s:\r\n", ina219_rails[i]);
-            printf("\tShunt Voltage: %d uV\r\n", shunt);
-            printf("\tRail Voltage: %d mV\r\n", voltage);
-            printf("\tPower: %d mW\r\n", power);
-            printf("\tCurrent: %d mA\r\n\r\n", current);
+            PRINTF("%s:\r\n", ina219_rails[i]);
+            PRINTF("\tShunt Voltage: %d uV\r\n", shunt);
+            PRINTF("\tRail Voltage: %d mV\r\n", voltage);
+            PRINTF("\tPower: %d mW\r\n", power);
+            PRINTF("\tCurrent: %d mA\r\n\r\n", current);
 
             overall_power += power;
         }
 
-        printf("System Power: %d mW\r\n", overall_power);
+        PRINTF("System Power: %d mW\r\n", overall_power);
 
         sleep(1000000);
     }

--- a/sw/tests/i2c_sim_test.c
+++ b/sw/tests/i2c_sim_test.c
@@ -86,7 +86,7 @@ int main(void) {
         CHECK_ELSE_TRAP(dif_i2c_irq_acknowledge(&i2c, kDifI2cIrqNak), kDifI2cOk)
     } while (nak_set);
 
-    printf("Write done\r\n");
+    PRINTF("Write done\r\n");
 
     // Reset address
     CHECK_ELSE_TRAP(dif_i2c_write_byte(&i2c, 0b10100000, kDifI2cFmtStart, false), kDifI2cOk)

--- a/sw/tests/sd_fpga_test.c
+++ b/sw/tests/sd_fpga_test.c
@@ -12,6 +12,7 @@
 #include "sleep.h"
 #include "trap.h"
 #include "uart.h"
+#include "util.h"
 
 #define DT_LEN 0x8
 #define FW_LEN 0x1800
@@ -58,13 +59,13 @@ int main(void) {
     gpt_find_partition(&spi, 0, &dt_lba);
     sd_copy_blocks(&spi, dt_lba, (unsigned char *)0x70010000, DT_LEN);
 
-    printf("Copied DT to 0x70010000\r\n");
+    PRINTF("Copied DT to 0x70010000\r\n");
 
     // Copy firmware to DRAM
     gpt_find_partition(&spi, 1, &fw_lba);
     sd_copy_blocks(&spi, fw_lba, (unsigned char *)0x80000000, FW_LEN);
 
-    printf("Copied FW to 0x80000000\r\n");
+    PRINTF("Copied FW to 0x80000000\r\n");
 
     void (*entry)(int, int, int) = (void (*)(int, int, int))0x80000000;
 

--- a/sw/tests/sd_speed_bench.c
+++ b/sw/tests/sd_speed_bench.c
@@ -11,6 +11,7 @@
 #include "sleep.h"
 #include "trap.h"
 #include "uart.h"
+#include "util.h"
 
 #define BENCH_LBA 0x800
 #define BENCH_LEN 0x1800
@@ -72,12 +73,12 @@ int main(void) {
     for (int i = 0; i < (sizeof(speeds) / sizeof(unsigned int)); i++) {
         unsigned long int mismatches = 0;
 
-        printf("--- Zeroing the memory region ---\r\n");
+        PRINTF("--- Zeroing the memory region ---\r\n");
         for (int x = 0; x < BENCH_LEN * 512 / 8; x++) {
             dram[x] = 0L;
         }
 
-        printf("--- Testing %d Hz ---\r\n", speeds[i]);
+        PRINTF("--- Testing %d Hz ---\r\n", speeds[i]);
         opentitan_qspi_set_speed(&spi, speeds[i]);
 
         // for(int b = 0; b < BENCH_LEN; b++){
@@ -87,20 +88,20 @@ int main(void) {
         // Copy check pattern to DRAM
         ret = sd_copy_blocks(&spi, BENCH_LBA, (unsigned char *)0x80000000, BENCH_LEN);
 
-        printf("----- Check pattern copied with return value %d. Verifying... -----\r\n", ret);
+        PRINTF("----- Check pattern copied with return value %d. Verifying... -----\r\n", ret);
 
         for (int j = 0; j < BENCH_LEN * 512 / 8; j++) {
             unsigned long int expected = ((4 * j) & 0xFFFFL) | (((4 * j + 1) & 0xFFFFL) << 16) |
                                          (((4 * j + 2) & 0xFFFFL) << 32) | (((4 * j + 3) & 0xFFFFL) << 48);
 
             if (expected != dram[j]) {
-                printf("!!! Mismatch @ 0x%x: Expected: 0x%lx <-> Actual: 0x%lx !!!\r\n", (unsigned long int)&dram[j],
+                PRINTF("!!! Mismatch @ 0x%x: Expected: 0x%lx <-> Actual: 0x%lx !!!\r\n", (unsigned long int)&dram[j],
                        expected, dram[j]);
                 mismatches++;
             }
         }
 
-        printf("----- %d Hz: %ld mismatches -----\r\n\n\n", speeds[i], mismatches);
+        PRINTF("----- %d Hz: %ld mismatches -----\r\n\n\n", speeds[i], mismatches);
     }
 
     return 0;

--- a/sw/tests/vga_fpga_test.c
+++ b/sw/tests/vga_fpga_test.c
@@ -10,6 +10,7 @@
 #include "trap.h"
 #include "uart.h"
 #include <stdint.h>
+#include "util.h"
 
 extern void *__base_dram;
 extern void *__base_vga;
@@ -245,14 +246,14 @@ int main(void) {
     init_uart(50000000, 115200);
     uart_initialized = 1;
 
-    printf_("Testing VGA\r\n");
+    PRINTF("Testing VGA\r\n");
 
     // Disable D-Cache
     asm volatile("addi t0, x0, 1\n   \
              csrrc x0, 0x701, t0\n" ::
                      : "t0");
 
-    printf_("Writing checkerboard to DRAM\r\n");
+    PRINTF("Writing checkerboard to DRAM\r\n");
 
     // checkerboard_640_350();
     color_matrix_640_480();
@@ -263,7 +264,7 @@ int main(void) {
     // init_vga_800_600();
     // init_vga_testmode();
 
-    printf_("VGA initialized\r\n");
+    PRINTF("VGA initialized\r\n");
 
     // render_gif_640_480((unsigned long int *) &_binary_graphics_image_bin_start);
     // render_gif_800_600((unsigned long int *) &_binary_graphics_image_bin_start);


### PR DESCRIPTION
# Overview

* Add PRINTF macro to wrap `printf` and display function name and line. This allows to enter debug mode by defining (`-DDEBUG`) or not defining (`-UDEBUG`) `DEBUG` macro in `sw/sw.mk`
* Fix some inconsistency in the tests between usage of `printf` and `printf_`, where the second is a wrapper of the former from `sw/include/printf.h`