### PR TITLE
target/xilinx: Fixes to top level and constraints

### DIFF
--- a/target/xilinx/src/cheshire_top_xilinx.sv
+++ b/target/xilinx/src/cheshire_top_xilinx.sv
@@ -92,7 +92,7 @@ module cheshire_top_xilinx
     RegAmoNumCuts     : 1,
     RegAmoPostCut     : 1,
     // RTC
-    RtcFreq           : 32768,
+    RtcFreq           : 1000000,
     // Features
     Bootrom           : 1,
     Uart              : 1,


### PR DESCRIPTION
* Fix `RtcFreq` parameter provided to SoC.
* Fix `test_mode_i` pin and MIG false paths in constraints.