### PR TITLE
hw: Fix cached LLC SPM remapping

### DIFF
--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -199,7 +199,8 @@ package cheshire_pkg;
   localparam doub_bt AmSpm    = 'h1000_0000;  // Cached region at bottom, uncached on top
 
   // Static masks
-  localparam doub_bt AmSpmRegionMask = 'h03FF_FFFF;
+  localparam doub_bt AmSpmBaseUncached = 'h1400_0000;
+  localparam doub_bt AmSpmRegionMask   = 'h03FF_FFFF;
 
   // AXI Xbar master indices
   typedef struct packed {

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -476,9 +476,9 @@ module cheshire_soc import cheshire_pkg::*; #(
     // This is necessary for routing in the LLC-internal interconnect.
     always_comb begin
       axi_llc_remap_req = axi_llc_cut_req;
-      if (axi_llc_cut_req.aw.addr & ~AmSpmRegionMask == AmSpmRegionUncached & ~AmSpmRegionMask)
+      if (axi_llc_cut_req.aw.addr & ~AmSpmRegionMask == AmSpmBaseUncached & ~AmSpmRegionMask)
         axi_llc_remap_req.aw.addr  = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.aw.addr);
-      if (axi_llc_cut_req.ar.addr & ~AmSpmRegionMask == AmSpmRegionUncached & ~AmSpmRegionMask)
+      if (axi_llc_cut_req.ar.addr & ~AmSpmRegionMask == AmSpmBaseUncached & ~AmSpmRegionMask)
         axi_llc_remap_req.ar.addr = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.ar.addr);
       axi_llc_cut_rsp = axi_llc_remap_rsp;
     end

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -475,10 +475,12 @@ module cheshire_soc import cheshire_pkg::*; #(
     // Remap both cached and uncached accesses to single base.
     // This is necessary for routing in the LLC-internal interconnect.
     always_comb begin
-      axi_llc_remap_req          = axi_llc_cut_req;
-      axi_llc_remap_req.aw.addr  = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.aw.addr);
-      axi_llc_remap_req.ar.addr  = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.ar.addr);
-      axi_llc_cut_rsp            = axi_llc_remap_rsp;
+      axi_llc_remap_req = axi_llc_cut_req;
+      if (axi_llc_cut_req.aw.addr & ~AmSpmRegionMask == AmSpmRegionUncached & ~AmSpmRegionMask)
+        axi_llc_remap_req.aw.addr  = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.aw.addr);
+      if (axi_llc_cut_req.ar.addr & ~AmSpmRegionMask == AmSpmRegionUncached & ~AmSpmRegionMask)
+        axi_llc_remap_req.ar.addr = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.ar.addr);
+      axi_llc_cut_rsp = axi_llc_remap_rsp;
     end
 
     axi_llc_reg_wrap #(


### PR DESCRIPTION
This previously mapped _all_ LLC accesses to its cached SPM region, breaking DRAM access.