### PR TITLE
hw: No ext IRQs by default, speed up MMC

### DIFF
--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -70,7 +70,6 @@ package cheshire_pkg;
     bit     DualCore;
     doub_bt NumExtIrqHarts;
     doub_bt NumExtDbgHarts;
-    shrt_bt NumExtIntrs;
     dw_bt   Core1UserAmoBit;
     dw_bt   CoreMaxTxns;
     dw_bt   CoreMaxTxnsPerId;

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -38,7 +38,7 @@ module cheshire_soc import cheshire_pkg::*; #(
   output reg_ext_req_t [iomsb(Cfg.RegExtNumSlv):0] reg_ext_slv_req_o,
   input  reg_ext_rsp_t [iomsb(Cfg.RegExtNumSlv):0] reg_ext_slv_rsp_i,
   // Interrupts from external devices
-  input  logic [iomsb(Cfg.NumExtIntrs):0] intr_ext_i,
+  input  logic [iomsb(NumExtIntrs):0] intr_ext_i,
   // Interrupts to external harts
   output logic [iomsb(Cfg.NumExtIrqHarts):0] meip_ext_o,
   output logic [iomsb(Cfg.NumExtIrqHarts):0] seip_ext_o,
@@ -900,8 +900,8 @@ module cheshire_soc import cheshire_pkg::*; #(
     .rst_ni,
     .reg_req_i  ( reg_out_req[RegOut.plic] ),
     .reg_rsp_o  ( reg_out_rsp[RegOut.plic] ),
-    .intr_src_i ( intr ),
-    .irq_o      ( irq  ),
+    .intr_src_i ( intr[NumIntIntrs+NumExtIntrs-1:0] ),  // Do not connect Ext IOMSB if it exists
+    .irq_o      ( irq ),
     .irq_id_o   ( ),
     .msip_o     ( )
   );

--- a/hw/rv_plic.cfg.hjson
+++ b/hw/rv_plic.cfg.hjson
@@ -7,7 +7,7 @@
 {
     instance_name: "rv_plic",
     param_values: {
-        src: 53,
+        src: 51,
         target: 2,  // We need *two targets* per hart: M and S modes
         prio: 7,
         nonstd_regs: 0  // Do *not* include these: MSIPs are not used and we use a 64 MiB address space

--- a/sw/boot/cheshire.dts
+++ b/sw/boot/cheshire.dts
@@ -86,7 +86,7 @@
       mmc@0 {
         compatible = "mmc-spi-slot";
         reg = <0>;
-        spi-max-frequency = <12500000>;
+        spi-max-frequency = <25000000>;
         voltage-ranges = <3300 3300>;
         disable-wp;
       };
@@ -108,7 +108,7 @@
       interrupt-controller;
       interrupts-extended = <&CPU0_intc 11 &CPU0_intc 9>;
       riscv,max-priority = <7>;
-      riscv,ndev = <19>;
+      riscv,ndev = <51>;
       reg = <0x0 0x4000000 0x0 0x4000000>;
     };
   };


### PR DESCRIPTION
* Limit IRQs in default config to those mapped.
* Speed up MMC in device tree to maximum speed of 25 MHz.