### PR TITLE
make: Optimize runtime, various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 nonfree/
 
 # Dependency files
-.deps
+.chs_deps
 .bender/
 
 # Software build files

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 nonfree/
 
 # Dependency files
-.chs_deps
 .bender/
 
 # Software build files

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CHS_ROOT ?= .
 
 include cheshire.mk
 
-# Inside the repo, forward (prefixed) all and nonfree targets
+# Inside the repo, forward (prefixed) all, nonfree, and clean targets
 all:
 	@$(MAKE) chs-all
 
@@ -19,3 +19,6 @@ all:
 
 nonfree-%:
 	@$(MAKE) chs-nonfree-$*
+
+clean-%:
+	@$(MAKE) chs-clean-$*

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -31,14 +31,16 @@ chs-all: chs-sw-all chs-hw-all chs-sim-all chs-xilinx-all
 # Dependencies #
 ################
 
-# Ensure both Bender dependencies and submodules are checked out
+# Ensure both Bender dependencies and (essential) submodules are checked out
 $(CHS_ROOT)/.deps:
 	$(BENDER) checkout
-	git submodule update --init --recursive
+	git submodule update --init --recursive sw/deps/printf
 	@touch $@
 
 # Make sure dependencies are more up-to-date than any targets run
+ifeq ($(shell stat $(CHS_ROOT)/.deps),)
 include $(CHS_ROOT)/.deps
+endif
 
 ######################
 # Nonfree components #

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -17,11 +17,11 @@ VSIM        ?= vsim
 CHS_ROOT      ?= $(shell $(BENDER) path cheshire)
 CHS_SW_DIR     = $(CHS_ROOT)/sw
 CHS_HW_DIR     = $(CHS_ROOT)/hw
-CHS_OTP_DIR    = $(shell $(BENDER) path opentitan_peripherals)
-CHS_CLINT_DIR  = $(shell $(BENDER) path clint)
-CHS_SLINK_DIR  = $(shell $(BENDER) path serial_link)
-CHS_VGA_DIR    = $(shell $(BENDER) path axi_vga)
-CHS_LLC_DIR    = $(shell $(BENDER) path axi_llc)
+CHS_OTP_DIR   := $(shell $(BENDER) path opentitan_peripherals)
+CHS_CLINT_DIR := $(shell $(BENDER) path clint)
+CHS_SLINK_DIR := $(shell $(BENDER) path serial_link)
+CHS_VGA_DIR   := $(shell $(BENDER) path axi_vga)
+CHS_LLC_DIR   := $(shell $(BENDER) path axi_llc)
 
 .PHONY: chs-all nonfree-init chs-sw-all chs-hw-all chs-bootrom-all chs-sim-all chs-xilinx-all
 
@@ -31,15 +31,17 @@ chs-all: chs-sw-all chs-hw-all chs-sim-all chs-xilinx-all
 # Dependencies #
 ################
 
+BENDER_ROOT ?= $(CHS_ROOT)
+
 # Ensure both Bender dependencies and (essential) submodules are checked out
-$(CHS_ROOT)/.deps:
+$(BENDER_ROOT)/.chs_deps:
 	$(BENDER) checkout
-	git submodule update --init --recursive sw/deps/printf
+	cd $(CHS_ROOT) && git submodule update --init --recursive sw/deps/printf
 	@touch $@
 
 # Make sure dependencies are more up-to-date than any targets run
-ifeq ($(shell stat $(CHS_ROOT)/.deps),)
-include $(CHS_ROOT)/.deps
+ifeq ($(shell test -f $(BENDER_ROOT)/.chs_deps && echo 1),)
+-include $(BENDER_ROOT)/.chs_deps
 endif
 
 ######################

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -84,28 +84,23 @@ $(CHS_ROOT)/hw/regs/axi_rt_reg_pkg.sv $(CHS_ROOT)/hw/regs/axi_rt_reg_top.sv: $(C
 # CLINT
 CLINTCORES = 1
 include $(CLINTROOT)/clint.mk
-$(CLINTROOT)/.generated: Bender.yml
-	$(MAKE) clint
-	@touch $@
+$(CLINTROOT)/.generated:
+	flock -x $@ $(MAKE) clint
 
 # OpenTitan peripherals
 include $(OTPROOT)/otp.mk
-$(OTPROOT)/.generated: $(CHS_ROOT)/hw/rv_plic.cfg.hjson Bender.yml
-	cp $< $(dir $@)/src/rv_plic/
-	$(MAKE) -j1 otp
-	@touch $@
+$(OTPROOT)/.generated: $(CHS_ROOT)/hw/rv_plic.cfg.hjson
+	flock -x $@ sh -c "cp $< $(dir $@)/src/rv_plic/; $(MAKE) -j1 otp"
 
 # AXI VGA
 include $(AXI_VGA_ROOT)/axi_vga.mk
-$(AXI_VGA_ROOT)/.generated: Bender.yml
-	$(MAKE) axi_vga
-	@touch $@
+$(AXI_VGA_ROOT)/.generated:
+	flock -x $@ $(MAKE) axi_vga
 
 # Custom serial link
 $(CHS_SLINK_DIR)/.generated: $(CHS_ROOT)/hw/serial_link.hjson
 	cp $< $(dir $@)/src/regs/serial_link_single_channel.hjson
-	$(MAKE) -C $(CHS_SLINK_DIR) update-regs
-	@touch $@
+	flock -x $@ $(MAKE) -C $(CHS_SLINK_DIR) update-regs
 
 chs-hw-all: $(CHS_ROOT)/hw/regs/cheshire_reg_pkg.sv $(CHS_ROOT)/hw/regs/cheshire_reg_top.sv
 chs-hw-all: $(CHS_ROOT)/hw/regs/axi_rt_reg_pkg.sv $(CHS_ROOT)/hw/regs/axi_rt_reg_top.sv

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -16,7 +16,8 @@ CHS_SW_OBJCOPY := $(CHS_SW_GCC_BINROOT)/riscv64-unknown-elf-objcopy
 CHS_SW_OBJDUMP := $(CHS_SW_GCC_BINROOT)/riscv64-unknown-elf-objdump
 CHS_SW_LTOPLUG := $(shell find $(shell dirname $(CHS_SW_GCC_BINROOT))/libexec/gcc/riscv64-unknown-elf/**/liblto_plugin.so)
 
-CHS_SW_LD_DIR    := $(CHS_SW_DIR)/link
+CHS_SW_DIR       ?= $(CHS_ROOT)/sw
+CHS_SW_LD_DIR    ?= $(CHS_SW_DIR)/link
 CHS_SW_ZSL_TGUID := 0269B26A-FD95-4CE4-98CF-941401412C62
 CHS_SW_DTB_TGUID := BA442F61-2AEF-42DE-9233-E4D75D3ACB9D
 CHS_SW_FW_TGUID  := 99EC86DA-3F5B-4B0D-8F4B-C4BACFA5F859
@@ -38,13 +39,13 @@ chs-sw-all: chs-sw-libs chs-sw-headers chs-sw-tests
 
 CHS_SW_DEPS_INCS  = -I$(CHS_SW_DIR)/deps/printf
 CHS_SW_DEPS_INCS += -I$(CHS_LLC_DIR)/sw/include
-CHS_SW_DEPS_INCS += -I$(CHS_OTP_DIR)
-CHS_SW_DEPS_INCS += -I$(CHS_OTP_DIR)/sw/include
+CHS_SW_DEPS_INCS += -I$(OTPROOT)
+CHS_SW_DEPS_INCS += -I$(OTPROOT)/sw/include
 CHS_SW_DEPS_SRCS  = $(CHS_SW_DIR)/deps/printf/printf.c
 CHS_SW_DEPS_SRCS += $(CHS_LLC_DIR)/sw/lib/axi_llc_reg32.c
-CHS_SW_DEPS_SRCS += $(wildcard $(CHS_OTP_DIR)/sw/device/lib/base/*.c)
-CHS_SW_DEPS_SRCS += $(wildcard $(CHS_OTP_DIR)/sw/device/lib/dif/*.c)
-CHS_SW_DEPS_SRCS += $(wildcard $(CHS_OTP_DIR)/sw/device/lib/dif/autogen/*.c)
+CHS_SW_DEPS_SRCS += $(wildcard $(OTPROOT)/sw/device/lib/base/*.c)
+CHS_SW_DEPS_SRCS += $(wildcard $(OTPROOT)/sw/device/lib/dif/*.c)
+CHS_SW_DEPS_SRCS += $(wildcard $(OTPROOT)/sw/device/lib/dif/autogen/*.c)
 
 #############
 # Libraries #
@@ -73,18 +74,18 @@ CHS_SW_GEN_HDRS += $$(CHS_SW_DIR)/include/regs/$(1).h
 
 $$(CHS_SW_DIR)/include/regs/$(1).h: $(2)
 	@mkdir -p $$(dir $$@)
-	$$(REGGEN) --cdefines $$< > $$@
+	$$(REGTOOL) --cdefines $$< > $$@
 endef
 
-$(eval $(call chs_sw_gen_hdr_rule,clint,$(CHS_CLINT_DIR)/src/clint.hjson $(CHS_CLINT_DIR)/.generated))
+$(eval $(call chs_sw_gen_hdr_rule,clint,$(CLINTROOT)/src/clint.hjson $(CLINTROOT)/.generated))
 $(eval $(call chs_sw_gen_hdr_rule,serial_link,$(CHS_ROOT)/hw/serial_link.hjson $(CHS_SLINK_DIR)/.generated))
-$(eval $(call chs_sw_gen_hdr_rule,axi_vga,$(CHS_VGA_DIR)/data/axi_vga.hjson $(CHS_VGA_DIR)/.generated))
+$(eval $(call chs_sw_gen_hdr_rule,axi_vga,$(AXI_VGA_ROOT)/data/axi_vga.hjson $(AXI_VGA_ROOT)/.generated))
 $(eval $(call chs_sw_gen_hdr_rule,axi_llc,$(CHS_LLC_DIR)/data/axi_llc_regs.hjson))
 $(eval $(call chs_sw_gen_hdr_rule,cheshire,$(CHS_ROOT)/hw/regs/cheshire_regs.hjson))
 $(eval $(call chs_sw_gen_hdr_rule,axi_rt,$(CHS_ROOT)/hw/regs/axi_rt_regs.hjson))
 
 # Generate headers for OT peripherals in the bendered repo itself
-CHS_SW_GEN_HDRS += $(CHS_OTP_DIR)/.generated
+CHS_SW_GEN_HDRS += $(OTPROOT)/.generated
 chs-sw-headers: $(CHS_SW_GEN_HDRS)
 
 ###############


### PR DESCRIPTION
* Dependencies (Bender and submodules) are only fetched once unless cleaned with `chs-clean-deps`
* Use immediate evaluation (`:=`) in various places to accelerate evaluation
* Avoid calling `shell bender path` as much as possible, adopting sub-dependency variable names where possible
* Enable parallel build (assuming no chained phonies)
* Scope some unscoped targets and variables with `chs` prefix