### PR TITLE
cva6: Add multicore support

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -83,7 +83,7 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cva6:
-    revision: bf806ffa1385876ab70b28df488fafe7ea573a7f
+    revision: 7a3df2a95396d0bb26c693e2e444bc6986a688ed
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -35,8 +35,8 @@ packages:
     - register_interface
     - tech_cells_generic
   axi_riscv_atomics:
-    revision: 97dcb14ef057cbe5bd70dda2060b5bb9e7e04c6d
-    version: 0.7.0
+    revision: 368fa5d324caaea7fec4b507941fed9f2d527c6c
+    version: 0.8.0
     source:
       Git: https://github.com/pulp-platform/axi_riscv_atomics.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -20,7 +20,7 @@ dependencies:
   clint:                    { git: "https://github.com/pulp-platform/clint.git",                  version: 0.1.0  }
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",           version: 1.29.0 }
   common_verification:      { git: "https://github.com/pulp-platform/common_verification.git",    version: 0.2.0  }
-  cva6:                     { git: "https://github.com/pulp-platform/cva6.git",                   rev: pulp-v0.3.1 }
+  cva6:                     { git: "https://github.com/pulp-platform/cva6.git",                   rev: pulp-v0.4.0 }
   iDMA:                     { git: "https://github.com/pulp-platform/iDMA.git",                   rev: 437ffa9    }  # TODO: master commit; use next release once out
   opentitan_peripherals:    { git: "https://github.com/pulp-platform/opentitan_peripherals.git",  version: 0.4.0  }
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git",     version: 0.4.1  }

--- a/Bender.yml
+++ b/Bender.yml
@@ -15,7 +15,7 @@ dependencies:
   apb_uart:                 { git: "https://github.com/pulp-platform/apb_uart.git",               version: 0.2.1  }
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                    version: 0.39.0 }
   axi_llc:                  { git: "https://github.com/pulp-platform/axi_llc.git",                version: 0.2.1  }
-  axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.7.0  }
+  axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.8.0  }
   axi_vga:                  { git: "https://github.com/pulp-platform/axi_vga.git",                version: 0.1.1  }
   clint:                    { git: "https://github.com/pulp-platform/clint.git",                  version: 0.1.0  }
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",           version: 1.29.0 }

--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -67,7 +67,7 @@ package cheshire_pkg;
     doub_bt Cva6ExtCieLength;
     bit     Cva6ExtCieOnTop;
     // Hart parameters
-    bit     DualCore;
+    bit [3:0] NumCores;
     doub_bt NumExtIrqHarts;
     doub_bt NumExtDbgHarts;
     dw_bt   Core1UserAmoBit;
@@ -463,7 +463,7 @@ package cheshire_pkg;
     Cva6ExtCieLength  : 'h2000_0000,  // [0x2.., 0x4..) is CIE, [0x4.., 0x8..) is non-CIE
     Cva6ExtCieOnTop   : 0,
     // Harts
-    DualCore          : 0,  // Only one core, but rest of config allows for two
+    NumCores          : 1,  // Only one core, but rest of config allows for two
     CoreMaxTxns       : 8,
     CoreMaxTxnsPerId  : 4,
     // Interrupts

--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -246,7 +246,7 @@ package cheshire_pkg;
 
   // AXI Xbar master indices
   typedef struct packed {
-    aw_bt cores;
+    aw_bt [3:0] cores;
     aw_bt dbg;
     aw_bt dma;
     aw_bt slink;
@@ -256,8 +256,10 @@ package cheshire_pkg;
   } axi_in_t;
 
   function automatic axi_in_t gen_axi_in(cheshire_cfg_t cfg);
-    axi_in_t ret = '{cores: 0, dbg: 1, default: '0};
-    int unsigned i = 1;
+    axi_in_t ret = '{default: '0};
+    int unsigned i = 0;
+    for (int j = 0; j < cfg.NumCores; j++) begin ret.cores[i] = i; i++; end
+    ret.dbg = i;
     if (cfg.Dma)        begin i++; ret.dma   = i; end
     if (cfg.SerialLink) begin i++; ret.slink = i; end
     if (cfg.Vga)        begin i++; ret.vga   = i; end
@@ -343,7 +345,7 @@ package cheshire_pkg;
     aw_bt slink;
     aw_bt vga;
     aw_bt axirt;
-    aw_bt clic;
+    aw_bt [3:0] clic;
     aw_bt irq_router;
     aw_bt ext_base;
     aw_bt num_out;
@@ -366,8 +368,12 @@ package cheshire_pkg;
     if (cfg.SerialLink) begin i++; ret.slink  = i; r++; ret.map[r] = '{i, AmSlink, AmSlink +'h1000}; end
     if (cfg.Vga)      begin i++; ret.vga      = i; r++; ret.map[r] = '{i, 'h0300_7000, 'h0300_8000}; end
     if (cfg.AxiRt)    begin i++; ret.axirt    = i; r++; ret.map[r] = '{i, 'h0300_8000, 'h0300_9000}; end
-    if (cfg.Clic)     begin i++; ret.clic     = i; r++; ret.map[r] = '{i, 'h0208_0000, 'h020c_0000}; end
-    if (cfg.IrqRouter) begin i++; ret.irq_router = i; r++; ret.map[r] = '{i, 'h0210_0000, 'h0214_0000}; end
+    if (cfg.IrqRouter) begin i++; ret.irq_router = i; r++; ret.map[r] = '{i, 'h0208_0000, 'h020c_0000}; end
+    if (cfg.Clic)     begin
+      for (int j = 0; j < cfg.NumCores; j++) begin
+        i++; ret.clic[j] = i; r++; ret.map[r] = '{i, 'h0800_0000 + j * 'h4_0000, 'h0800_0000 + (j + 1) * 'h4_0000};
+      end
+    end
     i++; r++;
     ret.ext_base  = i;
     ret.num_out   = i + cfg.RegExtNumSlv;

--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -469,7 +469,7 @@ package cheshire_pkg;
     Cva6ExtCieLength  : 'h2000_0000,  // [0x2.., 0x4..) is CIE, [0x4.., 0x8..) is non-CIE
     Cva6ExtCieOnTop   : 0,
     // Harts
-    NumCores          : 1,  // Only one core, but rest of config allows for two
+    NumCores          : 1,
     CoreMaxTxns       : 8,
     CoreMaxTxnsPerId  : 4,
     // Interrupts

--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -246,7 +246,7 @@ package cheshire_pkg;
 
   // AXI Xbar master indices
   typedef struct packed {
-    aw_bt [3:0] cores;
+    aw_bt [15:0] cores;
     aw_bt dbg;
     aw_bt dma;
     aw_bt slink;
@@ -345,7 +345,7 @@ package cheshire_pkg;
     aw_bt slink;
     aw_bt vga;
     aw_bt axirt;
-    aw_bt [3:0] clic;
+    aw_bt [15:0] clic;
     aw_bt irq_router;
     aw_bt ext_base;
     aw_bt num_out;

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -111,7 +111,7 @@ module cheshire_soc import cheshire_pkg::*; #(
   //  Interrupts  //
   //////////////////
 
-  localparam int unsigned NumIntHarts     = 1 + Cfg.DualCore;
+  localparam int unsigned NumIntHarts     = Cfg.NumCores;
   localparam int unsigned NumIrqHarts     = NumIntHarts + Cfg.NumExtIrqHarts;
   localparam int unsigned NumRtdIntrTgts  = 1 + NumIntHarts + Cfg.NumExtOutIntrTgts;
   localparam int unsigned NumClicSysIntrs = NumIntIntrs + Cfg.NumExtClicIntrs;
@@ -1618,8 +1618,6 @@ module cheshire_soc import cheshire_pkg::*; #(
   //////////////////
   //  Assertions  //
   //////////////////
-
-  `ASSERT_INIT(NoDualCoreSupport, ~Cfg.DualCore)
 
   // TODO: check that CVA6 and Cheshire config agree
   // TODO: check that all interconnect params agree

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -594,143 +594,145 @@ module cheshire_soc import cheshire_pkg::*; #(
   assign dbg_int_info     = {(NumIntHarts){ariane_pkg::DebugHartInfo}};
   assign dbg_int_unavail  = '0;
 
-  axi_cva6_req_t core_out_req, core_ur_req;
-  axi_cva6_rsp_t core_out_rsp, core_ur_rsp;
+  for (genvar i = 0; i < NumIntHarts; i++) begin : gen_cva6_cores
+    axi_cva6_req_t core_out_req, core_ur_req;
+    axi_cva6_rsp_t core_out_rsp, core_ur_rsp;
 
-  // CLIC interface
-  logic clic_irq_valid, clic_irq_ready;
-  logic clic_irq_kill_req, clic_irq_kill_ack;
-  logic clic_irq_shv;
-  logic [$clog2(NumClicIntrs)-1:0] clic_irq_id;
-  logic [7:0]        clic_irq_level;
-  riscv::priv_lvl_t  clic_irq_priv;
+    // CLIC interface
+    logic clic_irq_valid, clic_irq_ready;
+    logic clic_irq_kill_req, clic_irq_kill_ack;
+    logic clic_irq_shv;
+    logic [$clog2(NumClicIntrs)-1:0] clic_irq_id;
+    logic [7:0]        clic_irq_level;
+    riscv::priv_lvl_t  clic_irq_priv;
 
-  // Currently, we support only one core
-  cva6 #(
-    .ArianeCfg      ( Cva6Cfg ),
-    .AxiAddrWidth   ( Cfg.AddrWidth ),
-    .AxiDataWidth   ( Cfg.AxiDataWidth ),
-    .AxiIdWidth     ( Cva6IdWidth ),
-    .axi_ar_chan_t  ( axi_cva6_ar_chan_t ),
-    .axi_aw_chan_t  ( axi_cva6_aw_chan_t ),
-    .axi_w_chan_t   ( axi_cva6_w_chan_t  ),
-    .axi_req_t      ( axi_cva6_req_t ),
-    .axi_rsp_t      ( axi_cva6_rsp_t )
-  ) i_core_cva6 (
-    .clk_i,
-    .rst_ni,
-    .boot_addr_i      ( BootAddr ),
-    .hart_id_i        ( '0 ),
-    .irq_i            ( xeip[0] ),
-    .ipi_i            ( msip[0] ),
-    .time_irq_i       ( mtip[0] ),
-    .debug_req_i      ( dbg_int_req[0] ),
-    .clic_irq_valid_i ( clic_irq_valid ),
-    .clic_irq_id_i    ( clic_irq_id    ),
-    .clic_irq_level_i ( clic_irq_level ),
-    .clic_irq_priv_i  ( clic_irq_priv  ),
-    .clic_irq_shv_i   ( clic_irq_shv   ),
-    .clic_irq_ready_o ( clic_irq_ready ),
-    .clic_kill_req_i  ( clic_irq_kill_req ),
-    .clic_kill_ack_o  ( clic_irq_kill_ack ),
-    .rvfi_o           ( ),
-    .cvxif_req_o      ( ),
-    .cvxif_resp_i     ( '0 ),
-    .l15_req_o        ( ),
-    .l15_rtrn_i       ( '0 ),
-    .axi_req_o        ( core_out_req ),
-    .axi_resp_i       ( core_out_rsp )
-  );
-
-  // Generate CLIC for core if enabled
-  if (Cfg.Clic) begin : gen_clic
-
-    cheshire_intr_clic_t clic_intr;
-
-    // Connect interrupts to CLIC
-    assign clic_intr = '{
-      intr: intr_routed[IntrRtdCoreBase+0][NumClicSysIntrs-1:0],
-      core: '{
-        meip: xeip[0].m,
-        seip: xeip[0].s,
-        mtip: mtip[0],
-        msip: msip[0],
-        default: '0
-      }
-    };
-
-    clic #(
-      .N_SOURCE   ( NumClicIntrs ),
-      .INTCTLBITS ( Cfg.ClicIntCtlBits ),
-      .reg_req_t  ( reg_req_t ),
-      .reg_rsp_t  ( reg_rsp_t ),
-      .SSCLIC     ( 1 ),
-      .USCLIC     ( 0 )
-    ) i_clic (
+    // Currently, we support only one core
+    cva6 #(
+      .ArianeCfg      ( Cva6Cfg ),
+      .AxiAddrWidth   ( Cfg.AddrWidth ),
+      .AxiDataWidth   ( Cfg.AxiDataWidth ),
+      .AxiIdWidth     ( Cva6IdWidth ),
+      .axi_ar_chan_t  ( axi_cva6_ar_chan_t ),
+      .axi_aw_chan_t  ( axi_cva6_aw_chan_t ),
+      .axi_w_chan_t   ( axi_cva6_w_chan_t  ),
+      .axi_req_t      ( axi_cva6_req_t ),
+      .axi_rsp_t      ( axi_cva6_rsp_t )
+    ) i_core_cva6 (
       .clk_i,
       .rst_ni,
-      .reg_req_i      ( reg_out_req[RegOut.clic] ),
-      .reg_rsp_o      ( reg_out_rsp[RegOut.clic] ),
-      .intr_src_i     ( clic_intr ),
-      .irq_valid_o    ( clic_irq_valid ),
-      .irq_ready_i    ( clic_irq_ready ),
-      .irq_id_o       ( clic_irq_id    ),
-      .irq_level_o    ( clic_irq_level ),
-      .irq_shv_o      ( clic_irq_shv   ),
-      .irq_priv_o     ( clic_irq_priv  ),
-      .irq_kill_req_o ( clic_irq_kill_req ),
-      .irq_kill_ack_i ( clic_irq_kill_ack )
+      .boot_addr_i      ( BootAddr ),
+      .hart_id_i        ( 64'(i) ),
+      .irq_i            ( xeip[0] ),
+      .ipi_i            ( msip[0] ),
+      .time_irq_i       ( mtip[0] ),
+      .debug_req_i      ( dbg_int_req[i] ),
+      .clic_irq_valid_i ( clic_irq_valid ),
+      .clic_irq_id_i    ( clic_irq_id    ),
+      .clic_irq_level_i ( clic_irq_level ),
+      .clic_irq_priv_i  ( clic_irq_priv  ),
+      .clic_irq_shv_i   ( clic_irq_shv   ),
+      .clic_irq_ready_o ( clic_irq_ready ),
+      .clic_kill_req_i  ( clic_irq_kill_req ),
+      .clic_kill_ack_o  ( clic_irq_kill_ack ),
+      .rvfi_o           ( ),
+      .cvxif_req_o      ( ),
+      .cvxif_resp_i     ( '0 ),
+      .l15_req_o        ( ),
+      .l15_rtrn_i       ( '0 ),
+      .axi_req_o        ( core_out_req ),
+      .axi_resp_i       ( core_out_rsp )
     );
 
-  end else begin : gen_no_clic
+    // Generate CLIC for core if enabled
+    if (Cfg.Clic) begin : gen_clic
 
-    assign clic_irq_valid    = '0;
-    assign clic_irq_id       = '0;
-    assign clic_irq_level    = '0;
-    assign clic_irq_shv      = '0;
-    assign clic_irq_priv     = riscv::priv_lvl_t'(0);
-    assign clic_irq_kill_req = '0;
+      cheshire_intr_clic_t clic_intr;
 
+      // Connect interrupts to CLIC
+      assign clic_intr = '{
+        intr: intr_routed[IntrRtdCoreBase+0][NumClicSysIntrs-1:0],
+        core: '{
+          meip: xeip[0].m,
+          seip: xeip[0].s,
+          mtip: mtip[0],
+          msip: msip[0],
+          default: '0
+        }
+      };
+
+      clic #(
+        .N_SOURCE   ( NumClicIntrs ),
+        .INTCTLBITS ( Cfg.ClicIntCtlBits ),
+        .reg_req_t  ( reg_req_t ),
+        .reg_rsp_t  ( reg_rsp_t ),
+        .SSCLIC     ( 1 ),
+        .USCLIC     ( 0 )
+      ) i_clic (
+        .clk_i,
+        .rst_ni,
+        .reg_req_i      ( reg_out_req[RegOut.clic[i]] ),
+        .reg_rsp_o      ( reg_out_rsp[RegOut.clic[i]] ),
+        .intr_src_i     ( clic_intr ),
+        .irq_valid_o    ( clic_irq_valid ),
+        .irq_ready_i    ( clic_irq_ready ),
+        .irq_id_o       ( clic_irq_id    ),
+        .irq_level_o    ( clic_irq_level ),
+        .irq_shv_o      ( clic_irq_shv   ),
+        .irq_priv_o     ( clic_irq_priv  ),
+        .irq_kill_req_o ( clic_irq_kill_req ),
+        .irq_kill_ack_i ( clic_irq_kill_ack )
+      );
+
+    end else begin : gen_no_clic
+
+      assign clic_irq_valid    = '0;
+      assign clic_irq_id       = '0;
+      assign clic_irq_level    = '0;
+      assign clic_irq_shv      = '0;
+      assign clic_irq_priv     = riscv::priv_lvl_t'(0);
+      assign clic_irq_kill_req = '0;
+
+    end
+
+    // Map user to AMO domain as we are an atomics-capable master.
+    // As we are core 0, the core 1 and serial link AMO bits should *not* be set.
+    always_comb begin
+      core_ur_req         = core_out_req;
+      core_ur_req.aw.user = Cfg.AxiUserDefault;
+      core_ur_req.ar.user = Cfg.AxiUserDefault;
+      core_ur_req.w.user  = Cfg.AxiUserDefault;
+      // TODO: for additional cores, assign user bits between LSB and MSB accordingly
+      // TODO: for any other features, assign user bits accordingly
+      core_out_rsp        = core_ur_rsp;
+    end
+
+    // CVA6's ID encoding is wasteful; remap it statically pack into available bits
+    axi_id_serialize #(
+      .AxiSlvPortIdWidth      ( Cva6IdWidth     ),
+      .AxiSlvPortMaxTxns      ( Cfg.CoreMaxTxns ),
+      .AxiMstPortIdWidth      ( Cfg.AxiMstIdWidth      ),
+      .AxiMstPortMaxUniqIds   ( 2 ** Cfg.AxiMstIdWidth ),
+      .AxiMstPortMaxTxnsPerId ( Cfg.CoreMaxTxnsPerId   ),
+      .AxiAddrWidth           ( Cfg.AddrWidth    ),
+      .AxiDataWidth           ( Cfg.AxiDataWidth ),
+      .AxiUserWidth           ( Cfg.AxiUserWidth ),
+      .AtopSupport            ( 1 ),
+      .slv_req_t              ( axi_cva6_req_t ),
+      .slv_resp_t             ( axi_cva6_rsp_t ),
+      .mst_req_t              ( axi_mst_req_t  ),
+      .mst_resp_t             ( axi_mst_rsp_t  ),
+      .MstIdBaseOffset        ( '0 ),
+      .IdMapNumEntries        ( Cva6IdsUsed ),
+      .IdMap                  ( gen_cva6_id_map(Cfg) )
+    ) i_axi_id_serialize (
+      .clk_i,
+      .rst_ni,
+      .slv_req_i  ( core_ur_req ),
+      .slv_resp_o ( core_ur_rsp ),
+      .mst_req_o  ( axi_in_req[AxiIn.cores[i]] ),
+      .mst_resp_i ( axi_in_rsp[AxiIn.cores[i]] )
+    );
   end
-
-  // Map user to AMO domain as we are an atomics-capable master.
-  // As we are core 0, the core 1 and serial link AMO bits should *not* be set.
-  always_comb begin
-    core_ur_req         = core_out_req;
-    core_ur_req.aw.user = Cfg.AxiUserDefault;
-    core_ur_req.ar.user = Cfg.AxiUserDefault;
-    core_ur_req.w.user  = Cfg.AxiUserDefault;
-    // TODO: for additional cores, assign user bits between LSB and MSB accordingly
-    // TODO: for any other features, assign user bits accordingly
-    core_out_rsp        = core_ur_rsp;
-  end
-
-  // CVA6's ID encoding is wasteful; remap it statically pack into available bits
-  axi_id_serialize #(
-    .AxiSlvPortIdWidth      ( Cva6IdWidth     ),
-    .AxiSlvPortMaxTxns      ( Cfg.CoreMaxTxns ),
-    .AxiMstPortIdWidth      ( Cfg.AxiMstIdWidth      ),
-    .AxiMstPortMaxUniqIds   ( 2 ** Cfg.AxiMstIdWidth ),
-    .AxiMstPortMaxTxnsPerId ( Cfg.CoreMaxTxnsPerId   ),
-    .AxiAddrWidth           ( Cfg.AddrWidth    ),
-    .AxiDataWidth           ( Cfg.AxiDataWidth ),
-    .AxiUserWidth           ( Cfg.AxiUserWidth ),
-    .AtopSupport            ( 1 ),
-    .slv_req_t              ( axi_cva6_req_t ),
-    .slv_resp_t             ( axi_cva6_rsp_t ),
-    .mst_req_t              ( axi_mst_req_t  ),
-    .mst_resp_t             ( axi_mst_rsp_t  ),
-    .MstIdBaseOffset        ( '0 ),
-    .IdMapNumEntries        ( Cva6IdsUsed ),
-    .IdMap                  ( gen_cva6_id_map(Cfg) )
-  ) i_axi_id_serialize (
-    .clk_i,
-    .rst_ni,
-    .slv_req_i  ( core_ur_req ),
-    .slv_resp_o ( core_ur_rsp ),
-    .mst_req_o  ( axi_in_req[AxiIn.cores] ),
-    .mst_resp_i ( axi_in_rsp[AxiIn.cores] )
-  );
 
   /////////////////////////
   //  JTAG Debug Module  //

--- a/target/xilinx/scripts/run.tcl
+++ b/target/xilinx/scripts/run.tcl
@@ -59,9 +59,11 @@ wait_on_run impl_1
 #Check timing constraints
 open_run impl_1
 set timingrep [report_timing_summary -no_header -no_detailed_paths -return_string]
-if {! [string match -nocase {*timing constraints are met*} $timingrep]} {
-  send_msg_id {USER 1-1} ERROR {Timing constraints were not met.}
-  return -code error
+if {[info exists ::env(CHECK_TIMING)] && $::env(CHECK_TIMING)==1} {
+  if {! [string match -nocase {*timing constraints are met*} $timingrep]} {
+    send_msg_id {USER 1-1} ERROR {Timing constraints were not met.}
+    return -code error
+  }
 }
 
 # output Verilog netlist + SDC for timing simulation

--- a/target/xilinx/src/cheshire_top_xilinx.sv
+++ b/target/xilinx/src/cheshire_top_xilinx.sv
@@ -75,7 +75,7 @@ module cheshire_top_xilinx
     Cva6NrPMPEntries  : 0,
     Cva6ExtCieLength  : 'h2000_0000,
     // Harts
-    DualCore          : 0,  // Only one core, but rest of config allows for two
+    NumCores          : 1,  // Only one core, but rest of config allows for two
     CoreMaxTxns       : 8,
     CoreMaxTxnsPerId  : 4,
     // Interconnect

--- a/target/xilinx/src/cheshire_top_xilinx.sv
+++ b/target/xilinx/src/cheshire_top_xilinx.sv
@@ -75,7 +75,7 @@ module cheshire_top_xilinx
     Cva6NrPMPEntries  : 0,
     Cva6ExtCieLength  : 'h2000_0000,
     // Harts
-    NumCores          : 1,  // Only one core, but rest of config allows for two
+    NumCores          : 1,
     CoreMaxTxns       : 8,
     CoreMaxTxnsPerId  : 4,
     // Interconnect


### PR DESCRIPTION
Instantiate a parametric number of cva6 cores and corresponding CLICs. Self-invalidation coherence is provided by the version bumps of cva6 (`pulp-v0.4.0`) and the AXI AMO adapter (`v0.8.0`). Note: this does not augment the software stack for multicore (ZSBL etc.)