### PR TITLE
deps: Bump `axi_riscv_atomics` to v0.8.1

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -35,8 +35,8 @@ packages:
     - register_interface
     - tech_cells_generic
   axi_riscv_atomics:
-    revision: 368fa5d324caaea7fec4b507941fed9f2d527c6c
-    version: 0.8.0
+    revision: c3c3f2b65071841035c4e081c61c9b7be801d749
+    version: 0.8.1
     source:
       Git: https://github.com/pulp-platform/axi_riscv_atomics.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -15,7 +15,7 @@ dependencies:
   apb_uart:                 { git: "https://github.com/pulp-platform/apb_uart.git",               version: 0.2.1  }
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                    version: 0.39.0 }
   axi_llc:                  { git: "https://github.com/pulp-platform/axi_llc.git",                version: 0.2.1  }
-  axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.8.0  }
+  axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.8.1  }
   axi_vga:                  { git: "https://github.com/pulp-platform/axi_vga.git",                version: 0.1.1  }
   clint:                    { git: "https://github.com/pulp-platform/clint.git",                  version: 0.1.0  }
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",           version: 1.29.0 }


### PR DESCRIPTION
This version fixes a critical bug.