### PR TITLE
tb: Defer sim termination until UART transfer is complete

### DIFF
--- a/target/sim/src/tb_cheshire_soc.sv
+++ b/target/sim/src/tb_cheshire_soc.sv
@@ -55,6 +55,9 @@ module tb_cheshire_soc;
       fix.vip.jtag_wait_for_eoc(exit_code);
     end
 
+    // Wait for the UART to finish reading the current byte
+    wait (fix.vip.uart_reading_byte == 0);
+
     $finish;
   end
 

--- a/target/sim/src/vip_cheshire_soc.sv
+++ b/target/sim/src/vip_cheshire_soc.sv
@@ -332,16 +332,19 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
   byte_bt uart_boot_byte;
   logic   uart_boot_ena;
   logic   uart_boot_eoc;
+  logic   uart_reading_byte;
 
   initial begin
-    uart_rx       = 1;
-    uart_boot_eoc = 0;
-    uart_boot_ena = 0;
+    uart_rx           = 1;
+    uart_boot_eoc     = 0;
+    uart_boot_ena     = 0;
+    uart_reading_byte = 0;
   end
 
   task automatic uart_read_byte(output byte_bt bite);
     // Start bit
     @(negedge uart_tx);
+    uart_reading_byte = 1;
     #(UartBaudPeriod/2);
     // 8-bit byte
     for (int i = 0; i < 8; i++) begin
@@ -356,6 +359,7 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
     end
     // Stop bit
     #UartBaudPeriod;
+    uart_reading_byte=0;
   endtask
 
   task automatic uart_write_byte(input byte_bt bite);


### PR DESCRIPTION
Wait until the current byte has been transmitted before terminating the simulation. This is bound by the UART baud period x bauds per byte.

Tested in carfield (which does not cover `tb_cheshire_soc`)