### PR TITLE
hw: Fix AMO user IDs for cores

### DIFF
--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -76,7 +76,7 @@ package cheshire_pkg;
     bit [MaxCoresWidth-1:0] NumCores;
     doub_bt NumExtIrqHarts;
     doub_bt NumExtDbgHarts;
-    dw_bt   Core1UserAmoBit;
+    doub_bt CoreUserAmoOffs;
     dw_bt   CoreMaxTxns;
     dw_bt   CoreMaxTxnsPerId;
     // Interrupt parameters
@@ -501,6 +501,7 @@ package cheshire_pkg;
     NumCores          : 1,
     CoreMaxTxns       : 8,
     CoreMaxTxnsPerId  : 4,
+    CoreUserAmoOffs   : 0, // Convention: lower AMO bits for cores, MSB for serial link
     // Interrupts
     NumExtInIntrs     : 0,
     NumExtClicIntrs   : NumExtPlicIntrs,
@@ -515,8 +516,8 @@ package cheshire_pkg;
     AxiMstIdWidth     : 2,
     AxiMaxMstTrans    : 8,
     AxiMaxSlvTrans    : 8,
-    AxiUserAmoMsb     : 1,  // Convention: bit 0 for core(s), bit 1 for serial link
-    AxiUserAmoLsb     : 0,  // Convention: bit 0 for core(s), bit 1 for serial link
+    AxiUserAmoMsb     : 1, // Convention: lower AMO bits for cores, MSB for serial link
+    AxiUserAmoLsb     : 0, // Convention: lower AMO bits for cores, MSB for serial link
     AxiUserDefault    : 0,
     RegMaxReadTxns    : 8,
     RegMaxWriteTxns   : 8,
@@ -570,7 +571,7 @@ package cheshire_pkg;
     SlinkRegionEnd    : 'h2_0000_0000,
     SlinkTxAddrMask   : 'hFFFF_FFFF,
     SlinkTxAddrDomain : 'h0000_0000,
-    SlinkUserAmoBit   : 1,  // Upper atomics bit for serial link
+    SlinkUserAmoBit   : 1,  // Convention: lower AMO bits for cores, MSB for serial link
     // DMA config
     DmaConfMaxReadTxns  : 4,
     DmaConfMaxWriteTxns : 4,

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -707,14 +707,15 @@ module cheshire_soc import cheshire_pkg::*; #(
     end
 
     // Map user to AMO domain as we are an atomics-capable master.
-    // As we are core 0, the core 1 and serial link AMO bits should *not* be set.
+    // Within the provided AMO user range, we count up from the provided core AMO offset.
     always_comb begin
       core_ur_req         = core_out_req;
       core_ur_req.aw.user = Cfg.AxiUserDefault;
       core_ur_req.ar.user = Cfg.AxiUserDefault;
       core_ur_req.w.user  = Cfg.AxiUserDefault;
-      // TODO: for additional cores, assign user bits between LSB and MSB accordingly
-      // TODO: for any other features, assign user bits accordingly
+      core_ur_req.aw.user [Cfg.AxiUserAmoMsb:Cfg.AxiUserAmoLsb] = Cfg.CoreUserAmoOffs + i;
+      core_ur_req.ar.user [Cfg.AxiUserAmoMsb:Cfg.AxiUserAmoLsb] = Cfg.CoreUserAmoOffs + i;
+      core_ur_req.w.user  [Cfg.AxiUserAmoMsb:Cfg.AxiUserAmoLsb] = Cfg.CoreUserAmoOffs + i;
       core_out_rsp        = core_ur_rsp;
     end
 


### PR DESCRIPTION
When integrating multicore support into Cheshire, the AMO user bits were not made unique for each core. This MR fixes this.