### PR TITLE
hw: Fix Regbus address range in AXI crossbar

### DIFF
--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -332,7 +332,7 @@ package cheshire_pkg;
     axi_out_t ret = '{dbg: 0, reg_demux: 1, default: '0};
     int unsigned i = 1, r = 1;
     ret.map[0] = '{0, AmDbg,   AmDbg + 'h40000};
-    ret.map[1] = '{1, 'h0200_0000, 'h0800_0000};
+    ret.map[1] = '{1, 'h0200_0000, 'h0C00_0000};
     // Whether we have an LLC or a bypass, the output port is has its
     // own Xbar output with the specified region iff it is connected.
     if (cfg.LlcOutConnect) begin i++; r++; ret.llc = i;


### PR DESCRIPTION
* This PR fixes the regbus address map, with the CLIC currently inaccessible
* Verified with an [access test in carfield](https://github.com/pulp-platform/carfield/blob/main/sw/tests/bare-metal/hostd/vclic_basic.c)

@bluewww 