### PR TITLE
sw: Add parameter for default boot baudrate

### DIFF
--- a/sw/boot/zsl.c
+++ b/sw/boot/zsl.c
@@ -60,7 +60,7 @@ int main(void) {
     void *priv = (void *)(uintptr_t)*reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET);
 
     // Initialize UART
-    uart_init(&__base_uart, core_freq, 115200);
+    uart_init(&__base_uart, core_freq, __BOOT_BAUDRATE);
 
     // Print boot-critical cat, and also parameters
     printf(" /\\___/\\       Boot mode:       %d\r\n"

--- a/sw/include/params.h
+++ b/sw/include/params.h
@@ -30,6 +30,9 @@ extern void *__base_axirtgrd;
 extern void *__base_spm;
 extern void *__base_dram;
 
+// Default boot baudrate
+static const uint32_t __BOOT_BAUDRATE = 115200;
+
 // Maximum number of LBAs to copy to SPM for boot (48 KiB)
 static const uint64_t __BOOT_SPM_MAX_LBAS = 2 * 48;
 

--- a/sw/lib/hal/uart_debug.c
+++ b/sw/lib/hal/uart_debug.c
@@ -24,7 +24,7 @@ int uart_debug_init(void *uart_base, uint64_t core_freq) {
     CHECK_ASSERT(0x11, uart_base != 0);
     CHECK_ASSERT(0x12, core_freq != 0);
     // The UART debug mode uses the sane default 115.2kBaud
-    uart_init(uart_base, core_freq, 115200);
+    uart_init(uart_base, core_freq, __BOOT_BAUDRATE);
     fence();
     // Nothing went wrong
     return 0;

--- a/sw/tests/helloworld.c
+++ b/sw/tests/helloworld.c
@@ -17,7 +17,7 @@ int main(void) {
     char str[] = "Hello World!\r\n";
     uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
     uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
-    uart_init(&__base_uart, reset_freq, 115200);
+    uart_init(&__base_uart, reset_freq, __BOOT_BAUDRATE);
     uart_write_str(&__base_uart, str, sizeof(str));
     uart_write_flush(&__base_uart);
     return 0;


### PR DESCRIPTION
This avoids a replicated literal for the default boot baudrate (115200).