### PR TITLE
deps: Update `unbent` to v0.1.6

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -179,10 +179,11 @@ packages:
     dependencies:
     - common_verification
   unbent:
-    revision: 89ea12018002e6fae51f88e25320e79f57db8073
-    version: 0.1.5
+    revision: e9c9d5cfb635f2d4668c816ce9235798cfecb297
+    version: 0.1.6
     source:
       Git: https://github.com/pulp-platform/unbent.git
     dependencies:
+    - axi
     - common_cells
     - register_interface

--- a/Bender.yml
+++ b/Bender.yml
@@ -29,7 +29,7 @@ dependencies:
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git",     version: 0.4.2  }
   riscv-dbg:                { git: "https://github.com/pulp-platform/riscv-dbg.git",              version: 0.8.0  }
   serial_link:              { git: "https://github.com/pulp-platform/serial_link.git",            version: 1.1.0  }
-  unbent:                   { git: "https://github.com/pulp-platform/unbent.git",                 version: 0.1.5  }
+  unbent:                   { git: "https://github.com/pulp-platform/unbent.git",                 version: 0.1.6  }
 
 export_include_dirs:
   - hw/include


### PR DESCRIPTION
Adding support for atomics, see https://github.com/pulp-platform/unbent/pull/2