### PR TITLE
deps: Update `axi_riscv_atomics` to v0.8.2

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -35,8 +35,8 @@ packages:
     - register_interface
     - tech_cells_generic
   axi_riscv_atomics:
-    revision: c3c3f2b65071841035c4e081c61c9b7be801d749
-    version: 0.8.1
+    revision: 0ac3a78fe342c5a5b9b10bff49d58897f773059e
+    version: 0.8.2
     source:
       Git: https://github.com/pulp-platform/axi_riscv_atomics.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -15,7 +15,7 @@ dependencies:
   apb_uart:                 { git: "https://github.com/pulp-platform/apb_uart.git",               version: 0.2.1  }
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                    version: 0.39.0 }
   axi_llc:                  { git: "https://github.com/pulp-platform/axi_llc.git",                version: 0.2.1  }
-  axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.8.1  }
+  axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.8.2  }
   axi_rt:                   { git: "https://github.com/pulp-platform/axi_rt.git",                 version: 0.0.0-alpha.4 }
   axi_vga:                  { git: "https://github.com/pulp-platform/axi_vga.git",                version: 0.1.1  }
   clic:                     { git: "https://github.com/pulp-platform/clic.git",                   version: 2.0.0  }


### PR DESCRIPTION
This version contains critical bugfixes, see https://github.com/pulp-platform/axi_riscv_atomics/blob/v0.8.2/CHANGELOG.md

Investigating the failing CI right now.