### PR TITLE
hw: Disable CVA6 `FP8ALT` support

### DIFF
--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -483,7 +483,7 @@ package cheshire_pkg;
       XF16                  : 0,
       XF16ALT               : 0,
       XF8                   : 0,
-      XF8ALT                : 1,
+      XF8ALT                : 0,
       RVA                   : 1,
       RVB                   : 0,
       RVV                   : 0,


### PR DESCRIPTION
This PR disables `FP8ALT` support in Cheshire so that the only floating-point formats supported in the CVA6 FPU are `FP64` and `FP32`.