### PR TITLE
make: Ensure correct path to `xilinx.mk`

### DIFF
--- a/cheshire.mk
+++ b/cheshire.mk
@@ -159,7 +159,7 @@ CHS_SIM_ALL += $(CHS_ROOT)/target/sim/vsim/compile.cheshire_soc.tcl
 # FPGA Flow #
 #############
 
-include target/xilinx/xilinx.mk
+include $(CHS_ROOT)/target/xilinx/xilinx.mk
 
 #################################
 # Phonies (KEEP AT END OF FILE) #


### PR DESCRIPTION
If Cheshire is used in another project (like Iguana/Basilisk), this line will fail to find `xilinx.mk` since the current working directory is not the root of Cheshire.