### PR TITLE
treewide: Bump AXI-RT and fix AXI-RT functional tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,8 +84,8 @@ jobs:
         python-version: 3.9
         cache: pip
     -
-      name: Install tclint
-      run: pip install tclint
+      name: Install Python requirements
+      run: pip install -r requirements.txt
     -
       name: Run Tcllint
       run: tclint .  --style-spaces-in-braces --style-line-length 100

--- a/Bender.lock
+++ b/Bender.lock
@@ -44,8 +44,8 @@ packages:
     - common_cells
     - common_verification
   axi_rt:
-    revision: 56074a195b1c8b05f4bdd73674e437bbcb35f2cd
-    version: 0.0.0-alpha.7
+    revision: 641ea950e24722af747033f2ab85f0e48ea8d7f8
+    version: 0.0.0-alpha.9
     source:
       Git: https://github.com/pulp-platform/axi_rt.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -16,7 +16,7 @@ dependencies:
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                    version: 0.39.2 }
   axi_llc:                  { git: "https://github.com/pulp-platform/axi_llc.git",                version: 0.2.1  }
   axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.8.2  }
-  axi_rt:                   { git: "https://github.com/pulp-platform/axi_rt.git",                 version: 0.0.0-alpha.7 }
+  axi_rt:                   { git: "https://github.com/pulp-platform/axi_rt.git",                 version: 0.0.0-alpha.9 }
   axi_vga:                  { git: "https://github.com/pulp-platform/axi_vga.git",                version: 0.1.3  }
   clic:                     { git: "https://github.com/pulp-platform/clic.git",                   version: 2.0.0  }
   clint:                    { git: "https://github.com/pulp-platform/clint.git",                  version: 0.2.0  }

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Christopher Reinwardt <creinwar@student.ethz.ch>
 # Paul Scheffler <paulsc@iis.ee.ethz.ch>
 
-CHS_ROOT ?= $(shell realpath .)
+CHS_ROOT := $(shell realpath .)
 BENDER	 ?= bender -d $(CHS_ROOT)
 
 all:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Christopher Reinwardt <creinwar@student.ethz.ch>
 # Paul Scheffler <paulsc@iis.ee.ethz.ch>
 
-CHS_ROOT ?= $(shell pwd)
+CHS_ROOT ?= $(shell realpath .)
 BENDER	 ?= bender -d $(CHS_ROOT)
 
 all:

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -61,7 +61,7 @@ chs-clean-deps:
 ######################
 
 CHS_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/cheshire-nonfree.git
-CHS_NONFREE_COMMIT ?= f731b17
+CHS_NONFREE_COMMIT ?= 1f4092e
 
 CHS_PHONY += chs-nonfree-init
 chs-nonfree-init:

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -100,7 +100,7 @@ AXIRT_NUM_MGRS ?= 6
 AXIRT_NUM_SUBS ?= 2
 include $(AXIRTROOT)/axirt.mk
 $(AXIRTROOT)/.generated:
-	flock -x $@ $(MAKE) axirt_regs && touch $@
+	flock -x $@ $(MAKE) -B axirt_regs && touch $@
 
 # AXI VGA
 include $(AXI_VGA_ROOT)/axi_vga.mk

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -96,7 +96,7 @@ $(OTPROOT)/.generated: $(CHS_ROOT)/hw/rv_plic.cfg.hjson
 	flock -x $@ sh -c "cp $< $(dir $@)/src/rv_plic/; $(MAKE) -j1 otp" && touch $@
 
 # AXI RT
-AXIRT_NUM_MGRS ?= 8
+AXIRT_NUM_MGRS ?= 6
 AXIRT_NUM_SUBS ?= 2
 include $(AXIRTROOT)/axirt.mk
 $(AXIRTROOT)/.generated:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ yapf
 mkdocs
 mkdocs-material
 markdown-grid-tables
-tclint
+tclint==0.4.2
 flatdict

--- a/sw/include/params.h
+++ b/sw/include/params.h
@@ -51,7 +51,3 @@ static const uint64_t __BOOT_DTB_TYPE_GUID[2] = {0x42DE2AEFBA442F61UL, 0x9DCB3A5
 
 // GUID of firmware partition we boot into
 static const uint64_t __BOOT_FW_TYPE_GUID[2] = {0x4B0D3F5B99EC86DAUL, 0x59F8A5CFBAC44B8FUL};
-
-// Error code if an HW feature is not implemented but the programmer tries to
-// access it
-static const uint32_t HW_IMPL_ERR = 0x0CA7BEEF;

--- a/sw/include/params.h
+++ b/sw/include/params.h
@@ -51,3 +51,7 @@ static const uint64_t __BOOT_DTB_TYPE_GUID[2] = {0x42DE2AEFBA442F61UL, 0x9DCB3A5
 
 // GUID of firmware partition we boot into
 static const uint64_t __BOOT_FW_TYPE_GUID[2] = {0x4B0D3F5B99EC86DAUL, 0x59F8A5CFBAC44B8FUL};
+
+// Error code if an HW feature is not implemented but the programmer tries to
+// access it
+static const uint32_t HW_IMPL_ERR = 0x0CA7BEEF;

--- a/sw/include/regs/axi_rt.h
+++ b/sw/include/regs/axi_rt.h
@@ -14,13 +14,13 @@
 extern "C" {
 #endif
 // Maximum number of managers.
-#define AXI_RT_PARAM_NUM_MRG 8
+#define AXI_RT_PARAM_NUM_MRG 6
 
 // Configured number of subordinate regions.
 #define AXI_RT_PARAM_NUM_SUB 2
 
 // Configured number of required registers.
-#define AXI_RT_PARAM_NUM_REG 16
+#define AXI_RT_PARAM_NUM_REG 12
 
 // Register width
 #define AXI_RT_PARAM_REG_WIDTH 32
@@ -47,8 +47,6 @@ extern "C" {
 #define AXI_RT_RT_ENABLE_ENABLE_3_BIT 3
 #define AXI_RT_RT_ENABLE_ENABLE_4_BIT 4
 #define AXI_RT_RT_ENABLE_ENABLE_5_BIT 5
-#define AXI_RT_RT_ENABLE_ENABLE_6_BIT 6
-#define AXI_RT_RT_ENABLE_ENABLE_7_BIT 7
 
 // Is the RT inactive? (common parameters)
 #define AXI_RT_RT_BYPASSED_BYPASSED_FIELD_WIDTH 1
@@ -63,8 +61,6 @@ extern "C" {
 #define AXI_RT_RT_BYPASSED_BYPASSED_3_BIT 3
 #define AXI_RT_RT_BYPASSED_BYPASSED_4_BIT 4
 #define AXI_RT_RT_BYPASSED_BYPASSED_5_BIT 5
-#define AXI_RT_RT_BYPASSED_BYPASSED_6_BIT 6
-#define AXI_RT_RT_BYPASSED_BYPASSED_7_BIT 7
 
 // Fragmentation of the bursts in beats. (common parameters)
 #define AXI_RT_LEN_LIMIT_LEN_FIELD_WIDTH 8
@@ -100,14 +96,6 @@ extern "C" {
 #define AXI_RT_LEN_LIMIT_1_LEN_5_OFFSET 8
 #define AXI_RT_LEN_LIMIT_1_LEN_5_FIELD \
   ((bitfield_field32_t) { .mask = AXI_RT_LEN_LIMIT_1_LEN_5_MASK, .index = AXI_RT_LEN_LIMIT_1_LEN_5_OFFSET })
-#define AXI_RT_LEN_LIMIT_1_LEN_6_MASK 0xff
-#define AXI_RT_LEN_LIMIT_1_LEN_6_OFFSET 16
-#define AXI_RT_LEN_LIMIT_1_LEN_6_FIELD \
-  ((bitfield_field32_t) { .mask = AXI_RT_LEN_LIMIT_1_LEN_6_MASK, .index = AXI_RT_LEN_LIMIT_1_LEN_6_OFFSET })
-#define AXI_RT_LEN_LIMIT_1_LEN_7_MASK 0xff
-#define AXI_RT_LEN_LIMIT_1_LEN_7_OFFSET 24
-#define AXI_RT_LEN_LIMIT_1_LEN_7_FIELD \
-  ((bitfield_field32_t) { .mask = AXI_RT_LEN_LIMIT_1_LEN_7_MASK, .index = AXI_RT_LEN_LIMIT_1_LEN_7_OFFSET })
 
 // Enables the IMTU. (common parameters)
 #define AXI_RT_IMTU_ENABLE_ENABLE_FIELD_WIDTH 1
@@ -122,8 +110,6 @@ extern "C" {
 #define AXI_RT_IMTU_ENABLE_ENABLE_3_BIT 3
 #define AXI_RT_IMTU_ENABLE_ENABLE_4_BIT 4
 #define AXI_RT_IMTU_ENABLE_ENABLE_5_BIT 5
-#define AXI_RT_IMTU_ENABLE_ENABLE_6_BIT 6
-#define AXI_RT_IMTU_ENABLE_ENABLE_7_BIT 7
 
 // Resets both the period and the budget. (common parameters)
 #define AXI_RT_IMTU_ABORT_ABORT_FIELD_WIDTH 1
@@ -138,13 +124,11 @@ extern "C" {
 #define AXI_RT_IMTU_ABORT_ABORT_3_BIT 3
 #define AXI_RT_IMTU_ABORT_ABORT_4_BIT 4
 #define AXI_RT_IMTU_ABORT_ABORT_5_BIT 5
-#define AXI_RT_IMTU_ABORT_ABORT_6_BIT 6
-#define AXI_RT_IMTU_ABORT_ABORT_7_BIT 7
 
 // The lower 32bit of the start address. (common parameters)
 #define AXI_RT_START_ADDR_SUB_LOW_WRITE_BUDGET_FIELD_WIDTH 32
 #define AXI_RT_START_ADDR_SUB_LOW_WRITE_BUDGET_FIELDS_PER_REG 1
-#define AXI_RT_START_ADDR_SUB_LOW_MULTIREG_COUNT 16
+#define AXI_RT_START_ADDR_SUB_LOW_MULTIREG_COUNT 12
 
 // The lower 32bit of the start address.
 #define AXI_RT_START_ADDR_SUB_LOW_0_REG_OFFSET 0x24
@@ -182,600 +166,456 @@ extern "C" {
 // The lower 32bit of the start address.
 #define AXI_RT_START_ADDR_SUB_LOW_11_REG_OFFSET 0x50
 
-// The lower 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_LOW_12_REG_OFFSET 0x54
-
-// The lower 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_LOW_13_REG_OFFSET 0x58
-
-// The lower 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_LOW_14_REG_OFFSET 0x5c
-
-// The lower 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_LOW_15_REG_OFFSET 0x60
-
 // The higher 32bit of the start address. (common parameters)
 #define AXI_RT_START_ADDR_SUB_HIGH_WRITE_BUDGET_FIELD_WIDTH 32
 #define AXI_RT_START_ADDR_SUB_HIGH_WRITE_BUDGET_FIELDS_PER_REG 1
-#define AXI_RT_START_ADDR_SUB_HIGH_MULTIREG_COUNT 16
+#define AXI_RT_START_ADDR_SUB_HIGH_MULTIREG_COUNT 12
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_0_REG_OFFSET 0x64
+#define AXI_RT_START_ADDR_SUB_HIGH_0_REG_OFFSET 0x54
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_1_REG_OFFSET 0x68
+#define AXI_RT_START_ADDR_SUB_HIGH_1_REG_OFFSET 0x58
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_2_REG_OFFSET 0x6c
+#define AXI_RT_START_ADDR_SUB_HIGH_2_REG_OFFSET 0x5c
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_3_REG_OFFSET 0x70
+#define AXI_RT_START_ADDR_SUB_HIGH_3_REG_OFFSET 0x60
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_4_REG_OFFSET 0x74
+#define AXI_RT_START_ADDR_SUB_HIGH_4_REG_OFFSET 0x64
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_5_REG_OFFSET 0x78
+#define AXI_RT_START_ADDR_SUB_HIGH_5_REG_OFFSET 0x68
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_6_REG_OFFSET 0x7c
+#define AXI_RT_START_ADDR_SUB_HIGH_6_REG_OFFSET 0x6c
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_7_REG_OFFSET 0x80
+#define AXI_RT_START_ADDR_SUB_HIGH_7_REG_OFFSET 0x70
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_8_REG_OFFSET 0x84
+#define AXI_RT_START_ADDR_SUB_HIGH_8_REG_OFFSET 0x74
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_9_REG_OFFSET 0x88
+#define AXI_RT_START_ADDR_SUB_HIGH_9_REG_OFFSET 0x78
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_10_REG_OFFSET 0x8c
+#define AXI_RT_START_ADDR_SUB_HIGH_10_REG_OFFSET 0x7c
 
 // The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_11_REG_OFFSET 0x90
-
-// The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_12_REG_OFFSET 0x94
-
-// The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_13_REG_OFFSET 0x98
-
-// The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_14_REG_OFFSET 0x9c
-
-// The higher 32bit of the start address.
-#define AXI_RT_START_ADDR_SUB_HIGH_15_REG_OFFSET 0xa0
+#define AXI_RT_START_ADDR_SUB_HIGH_11_REG_OFFSET 0x80
 
 // The lower 32bit of the end address. (common parameters)
 #define AXI_RT_END_ADDR_SUB_LOW_WRITE_BUDGET_FIELD_WIDTH 32
 #define AXI_RT_END_ADDR_SUB_LOW_WRITE_BUDGET_FIELDS_PER_REG 1
-#define AXI_RT_END_ADDR_SUB_LOW_MULTIREG_COUNT 16
+#define AXI_RT_END_ADDR_SUB_LOW_MULTIREG_COUNT 12
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_0_REG_OFFSET 0xa4
+#define AXI_RT_END_ADDR_SUB_LOW_0_REG_OFFSET 0x84
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_1_REG_OFFSET 0xa8
+#define AXI_RT_END_ADDR_SUB_LOW_1_REG_OFFSET 0x88
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_2_REG_OFFSET 0xac
+#define AXI_RT_END_ADDR_SUB_LOW_2_REG_OFFSET 0x8c
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_3_REG_OFFSET 0xb0
+#define AXI_RT_END_ADDR_SUB_LOW_3_REG_OFFSET 0x90
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_4_REG_OFFSET 0xb4
+#define AXI_RT_END_ADDR_SUB_LOW_4_REG_OFFSET 0x94
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_5_REG_OFFSET 0xb8
+#define AXI_RT_END_ADDR_SUB_LOW_5_REG_OFFSET 0x98
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_6_REG_OFFSET 0xbc
+#define AXI_RT_END_ADDR_SUB_LOW_6_REG_OFFSET 0x9c
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_7_REG_OFFSET 0xc0
+#define AXI_RT_END_ADDR_SUB_LOW_7_REG_OFFSET 0xa0
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_8_REG_OFFSET 0xc4
+#define AXI_RT_END_ADDR_SUB_LOW_8_REG_OFFSET 0xa4
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_9_REG_OFFSET 0xc8
+#define AXI_RT_END_ADDR_SUB_LOW_9_REG_OFFSET 0xa8
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_10_REG_OFFSET 0xcc
+#define AXI_RT_END_ADDR_SUB_LOW_10_REG_OFFSET 0xac
 
 // The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_11_REG_OFFSET 0xd0
-
-// The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_12_REG_OFFSET 0xd4
-
-// The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_13_REG_OFFSET 0xd8
-
-// The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_14_REG_OFFSET 0xdc
-
-// The lower 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_LOW_15_REG_OFFSET 0xe0
+#define AXI_RT_END_ADDR_SUB_LOW_11_REG_OFFSET 0xb0
 
 // The higher 32bit of the end address. (common parameters)
 #define AXI_RT_END_ADDR_SUB_HIGH_WRITE_BUDGET_FIELD_WIDTH 32
 #define AXI_RT_END_ADDR_SUB_HIGH_WRITE_BUDGET_FIELDS_PER_REG 1
-#define AXI_RT_END_ADDR_SUB_HIGH_MULTIREG_COUNT 16
+#define AXI_RT_END_ADDR_SUB_HIGH_MULTIREG_COUNT 12
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_0_REG_OFFSET 0xe4
+#define AXI_RT_END_ADDR_SUB_HIGH_0_REG_OFFSET 0xb4
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_1_REG_OFFSET 0xe8
+#define AXI_RT_END_ADDR_SUB_HIGH_1_REG_OFFSET 0xb8
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_2_REG_OFFSET 0xec
+#define AXI_RT_END_ADDR_SUB_HIGH_2_REG_OFFSET 0xbc
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_3_REG_OFFSET 0xf0
+#define AXI_RT_END_ADDR_SUB_HIGH_3_REG_OFFSET 0xc0
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_4_REG_OFFSET 0xf4
+#define AXI_RT_END_ADDR_SUB_HIGH_4_REG_OFFSET 0xc4
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_5_REG_OFFSET 0xf8
+#define AXI_RT_END_ADDR_SUB_HIGH_5_REG_OFFSET 0xc8
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_6_REG_OFFSET 0xfc
+#define AXI_RT_END_ADDR_SUB_HIGH_6_REG_OFFSET 0xcc
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_7_REG_OFFSET 0x100
+#define AXI_RT_END_ADDR_SUB_HIGH_7_REG_OFFSET 0xd0
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_8_REG_OFFSET 0x104
+#define AXI_RT_END_ADDR_SUB_HIGH_8_REG_OFFSET 0xd4
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_9_REG_OFFSET 0x108
+#define AXI_RT_END_ADDR_SUB_HIGH_9_REG_OFFSET 0xd8
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_10_REG_OFFSET 0x10c
+#define AXI_RT_END_ADDR_SUB_HIGH_10_REG_OFFSET 0xdc
 
 // The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_11_REG_OFFSET 0x110
-
-// The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_12_REG_OFFSET 0x114
-
-// The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_13_REG_OFFSET 0x118
-
-// The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_14_REG_OFFSET 0x11c
-
-// The higher 32bit of the end address.
-#define AXI_RT_END_ADDR_SUB_HIGH_15_REG_OFFSET 0x120
+#define AXI_RT_END_ADDR_SUB_HIGH_11_REG_OFFSET 0xe0
 
 // The budget for writes. (common parameters)
 #define AXI_RT_WRITE_BUDGET_WRITE_BUDGET_FIELD_WIDTH 32
 #define AXI_RT_WRITE_BUDGET_WRITE_BUDGET_FIELDS_PER_REG 1
-#define AXI_RT_WRITE_BUDGET_MULTIREG_COUNT 16
+#define AXI_RT_WRITE_BUDGET_MULTIREG_COUNT 12
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_0_REG_OFFSET 0x124
+#define AXI_RT_WRITE_BUDGET_0_REG_OFFSET 0xe4
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_1_REG_OFFSET 0x128
+#define AXI_RT_WRITE_BUDGET_1_REG_OFFSET 0xe8
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_2_REG_OFFSET 0x12c
+#define AXI_RT_WRITE_BUDGET_2_REG_OFFSET 0xec
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_3_REG_OFFSET 0x130
+#define AXI_RT_WRITE_BUDGET_3_REG_OFFSET 0xf0
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_4_REG_OFFSET 0x134
+#define AXI_RT_WRITE_BUDGET_4_REG_OFFSET 0xf4
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_5_REG_OFFSET 0x138
+#define AXI_RT_WRITE_BUDGET_5_REG_OFFSET 0xf8
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_6_REG_OFFSET 0x13c
+#define AXI_RT_WRITE_BUDGET_6_REG_OFFSET 0xfc
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_7_REG_OFFSET 0x140
+#define AXI_RT_WRITE_BUDGET_7_REG_OFFSET 0x100
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_8_REG_OFFSET 0x144
+#define AXI_RT_WRITE_BUDGET_8_REG_OFFSET 0x104
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_9_REG_OFFSET 0x148
+#define AXI_RT_WRITE_BUDGET_9_REG_OFFSET 0x108
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_10_REG_OFFSET 0x14c
+#define AXI_RT_WRITE_BUDGET_10_REG_OFFSET 0x10c
 
 // The budget for writes.
-#define AXI_RT_WRITE_BUDGET_11_REG_OFFSET 0x150
-
-// The budget for writes.
-#define AXI_RT_WRITE_BUDGET_12_REG_OFFSET 0x154
-
-// The budget for writes.
-#define AXI_RT_WRITE_BUDGET_13_REG_OFFSET 0x158
-
-// The budget for writes.
-#define AXI_RT_WRITE_BUDGET_14_REG_OFFSET 0x15c
-
-// The budget for writes.
-#define AXI_RT_WRITE_BUDGET_15_REG_OFFSET 0x160
+#define AXI_RT_WRITE_BUDGET_11_REG_OFFSET 0x110
 
 // The budget for reads. (common parameters)
 #define AXI_RT_READ_BUDGET_READ_BUDGET_FIELD_WIDTH 32
 #define AXI_RT_READ_BUDGET_READ_BUDGET_FIELDS_PER_REG 1
-#define AXI_RT_READ_BUDGET_MULTIREG_COUNT 16
+#define AXI_RT_READ_BUDGET_MULTIREG_COUNT 12
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_0_REG_OFFSET 0x164
+#define AXI_RT_READ_BUDGET_0_REG_OFFSET 0x114
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_1_REG_OFFSET 0x168
+#define AXI_RT_READ_BUDGET_1_REG_OFFSET 0x118
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_2_REG_OFFSET 0x16c
+#define AXI_RT_READ_BUDGET_2_REG_OFFSET 0x11c
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_3_REG_OFFSET 0x170
+#define AXI_RT_READ_BUDGET_3_REG_OFFSET 0x120
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_4_REG_OFFSET 0x174
+#define AXI_RT_READ_BUDGET_4_REG_OFFSET 0x124
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_5_REG_OFFSET 0x178
+#define AXI_RT_READ_BUDGET_5_REG_OFFSET 0x128
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_6_REG_OFFSET 0x17c
+#define AXI_RT_READ_BUDGET_6_REG_OFFSET 0x12c
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_7_REG_OFFSET 0x180
+#define AXI_RT_READ_BUDGET_7_REG_OFFSET 0x130
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_8_REG_OFFSET 0x184
+#define AXI_RT_READ_BUDGET_8_REG_OFFSET 0x134
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_9_REG_OFFSET 0x188
+#define AXI_RT_READ_BUDGET_9_REG_OFFSET 0x138
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_10_REG_OFFSET 0x18c
+#define AXI_RT_READ_BUDGET_10_REG_OFFSET 0x13c
 
 // The budget for reads.
-#define AXI_RT_READ_BUDGET_11_REG_OFFSET 0x190
-
-// The budget for reads.
-#define AXI_RT_READ_BUDGET_12_REG_OFFSET 0x194
-
-// The budget for reads.
-#define AXI_RT_READ_BUDGET_13_REG_OFFSET 0x198
-
-// The budget for reads.
-#define AXI_RT_READ_BUDGET_14_REG_OFFSET 0x19c
-
-// The budget for reads.
-#define AXI_RT_READ_BUDGET_15_REG_OFFSET 0x1a0
+#define AXI_RT_READ_BUDGET_11_REG_OFFSET 0x140
 
 // The period for writes. (common parameters)
 #define AXI_RT_WRITE_PERIOD_WRITE_PERIOD_FIELD_WIDTH 32
 #define AXI_RT_WRITE_PERIOD_WRITE_PERIOD_FIELDS_PER_REG 1
-#define AXI_RT_WRITE_PERIOD_MULTIREG_COUNT 16
+#define AXI_RT_WRITE_PERIOD_MULTIREG_COUNT 12
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_0_REG_OFFSET 0x1a4
+#define AXI_RT_WRITE_PERIOD_0_REG_OFFSET 0x144
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_1_REG_OFFSET 0x1a8
+#define AXI_RT_WRITE_PERIOD_1_REG_OFFSET 0x148
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_2_REG_OFFSET 0x1ac
+#define AXI_RT_WRITE_PERIOD_2_REG_OFFSET 0x14c
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_3_REG_OFFSET 0x1b0
+#define AXI_RT_WRITE_PERIOD_3_REG_OFFSET 0x150
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_4_REG_OFFSET 0x1b4
+#define AXI_RT_WRITE_PERIOD_4_REG_OFFSET 0x154
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_5_REG_OFFSET 0x1b8
+#define AXI_RT_WRITE_PERIOD_5_REG_OFFSET 0x158
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_6_REG_OFFSET 0x1bc
+#define AXI_RT_WRITE_PERIOD_6_REG_OFFSET 0x15c
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_7_REG_OFFSET 0x1c0
+#define AXI_RT_WRITE_PERIOD_7_REG_OFFSET 0x160
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_8_REG_OFFSET 0x1c4
+#define AXI_RT_WRITE_PERIOD_8_REG_OFFSET 0x164
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_9_REG_OFFSET 0x1c8
+#define AXI_RT_WRITE_PERIOD_9_REG_OFFSET 0x168
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_10_REG_OFFSET 0x1cc
+#define AXI_RT_WRITE_PERIOD_10_REG_OFFSET 0x16c
 
 // The period for writes.
-#define AXI_RT_WRITE_PERIOD_11_REG_OFFSET 0x1d0
-
-// The period for writes.
-#define AXI_RT_WRITE_PERIOD_12_REG_OFFSET 0x1d4
-
-// The period for writes.
-#define AXI_RT_WRITE_PERIOD_13_REG_OFFSET 0x1d8
-
-// The period for writes.
-#define AXI_RT_WRITE_PERIOD_14_REG_OFFSET 0x1dc
-
-// The period for writes.
-#define AXI_RT_WRITE_PERIOD_15_REG_OFFSET 0x1e0
+#define AXI_RT_WRITE_PERIOD_11_REG_OFFSET 0x170
 
 // The period for reads. (common parameters)
 #define AXI_RT_READ_PERIOD_READ_PERIOD_FIELD_WIDTH 32
 #define AXI_RT_READ_PERIOD_READ_PERIOD_FIELDS_PER_REG 1
-#define AXI_RT_READ_PERIOD_MULTIREG_COUNT 16
+#define AXI_RT_READ_PERIOD_MULTIREG_COUNT 12
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_0_REG_OFFSET 0x1e4
+#define AXI_RT_READ_PERIOD_0_REG_OFFSET 0x174
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_1_REG_OFFSET 0x1e8
+#define AXI_RT_READ_PERIOD_1_REG_OFFSET 0x178
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_2_REG_OFFSET 0x1ec
+#define AXI_RT_READ_PERIOD_2_REG_OFFSET 0x17c
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_3_REG_OFFSET 0x1f0
+#define AXI_RT_READ_PERIOD_3_REG_OFFSET 0x180
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_4_REG_OFFSET 0x1f4
+#define AXI_RT_READ_PERIOD_4_REG_OFFSET 0x184
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_5_REG_OFFSET 0x1f8
+#define AXI_RT_READ_PERIOD_5_REG_OFFSET 0x188
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_6_REG_OFFSET 0x1fc
+#define AXI_RT_READ_PERIOD_6_REG_OFFSET 0x18c
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_7_REG_OFFSET 0x200
+#define AXI_RT_READ_PERIOD_7_REG_OFFSET 0x190
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_8_REG_OFFSET 0x204
+#define AXI_RT_READ_PERIOD_8_REG_OFFSET 0x194
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_9_REG_OFFSET 0x208
+#define AXI_RT_READ_PERIOD_9_REG_OFFSET 0x198
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_10_REG_OFFSET 0x20c
+#define AXI_RT_READ_PERIOD_10_REG_OFFSET 0x19c
 
 // The period for reads.
-#define AXI_RT_READ_PERIOD_11_REG_OFFSET 0x210
-
-// The period for reads.
-#define AXI_RT_READ_PERIOD_12_REG_OFFSET 0x214
-
-// The period for reads.
-#define AXI_RT_READ_PERIOD_13_REG_OFFSET 0x218
-
-// The period for reads.
-#define AXI_RT_READ_PERIOD_14_REG_OFFSET 0x21c
-
-// The period for reads.
-#define AXI_RT_READ_PERIOD_15_REG_OFFSET 0x220
+#define AXI_RT_READ_PERIOD_11_REG_OFFSET 0x1a0
 
 // The budget left for writes. (common parameters)
 #define AXI_RT_WRITE_BUDGET_LEFT_WRITE_BUDGET_LEFT_FIELD_WIDTH 32
 #define AXI_RT_WRITE_BUDGET_LEFT_WRITE_BUDGET_LEFT_FIELDS_PER_REG 1
-#define AXI_RT_WRITE_BUDGET_LEFT_MULTIREG_COUNT 16
+#define AXI_RT_WRITE_BUDGET_LEFT_MULTIREG_COUNT 12
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_0_REG_OFFSET 0x224
+#define AXI_RT_WRITE_BUDGET_LEFT_0_REG_OFFSET 0x1a4
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_1_REG_OFFSET 0x228
+#define AXI_RT_WRITE_BUDGET_LEFT_1_REG_OFFSET 0x1a8
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_2_REG_OFFSET 0x22c
+#define AXI_RT_WRITE_BUDGET_LEFT_2_REG_OFFSET 0x1ac
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_3_REG_OFFSET 0x230
+#define AXI_RT_WRITE_BUDGET_LEFT_3_REG_OFFSET 0x1b0
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_4_REG_OFFSET 0x234
+#define AXI_RT_WRITE_BUDGET_LEFT_4_REG_OFFSET 0x1b4
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_5_REG_OFFSET 0x238
+#define AXI_RT_WRITE_BUDGET_LEFT_5_REG_OFFSET 0x1b8
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_6_REG_OFFSET 0x23c
+#define AXI_RT_WRITE_BUDGET_LEFT_6_REG_OFFSET 0x1bc
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_7_REG_OFFSET 0x240
+#define AXI_RT_WRITE_BUDGET_LEFT_7_REG_OFFSET 0x1c0
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_8_REG_OFFSET 0x244
+#define AXI_RT_WRITE_BUDGET_LEFT_8_REG_OFFSET 0x1c4
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_9_REG_OFFSET 0x248
+#define AXI_RT_WRITE_BUDGET_LEFT_9_REG_OFFSET 0x1c8
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_10_REG_OFFSET 0x24c
+#define AXI_RT_WRITE_BUDGET_LEFT_10_REG_OFFSET 0x1cc
 
 // The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_11_REG_OFFSET 0x250
-
-// The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_12_REG_OFFSET 0x254
-
-// The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_13_REG_OFFSET 0x258
-
-// The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_14_REG_OFFSET 0x25c
-
-// The budget left for writes.
-#define AXI_RT_WRITE_BUDGET_LEFT_15_REG_OFFSET 0x260
+#define AXI_RT_WRITE_BUDGET_LEFT_11_REG_OFFSET 0x1d0
 
 // The budget left for reads. (common parameters)
 #define AXI_RT_READ_BUDGET_LEFT_READ_BUDGET_LEFT_FIELD_WIDTH 32
 #define AXI_RT_READ_BUDGET_LEFT_READ_BUDGET_LEFT_FIELDS_PER_REG 1
-#define AXI_RT_READ_BUDGET_LEFT_MULTIREG_COUNT 16
+#define AXI_RT_READ_BUDGET_LEFT_MULTIREG_COUNT 12
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_0_REG_OFFSET 0x264
+#define AXI_RT_READ_BUDGET_LEFT_0_REG_OFFSET 0x1d4
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_1_REG_OFFSET 0x268
+#define AXI_RT_READ_BUDGET_LEFT_1_REG_OFFSET 0x1d8
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_2_REG_OFFSET 0x26c
+#define AXI_RT_READ_BUDGET_LEFT_2_REG_OFFSET 0x1dc
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_3_REG_OFFSET 0x270
+#define AXI_RT_READ_BUDGET_LEFT_3_REG_OFFSET 0x1e0
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_4_REG_OFFSET 0x274
+#define AXI_RT_READ_BUDGET_LEFT_4_REG_OFFSET 0x1e4
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_5_REG_OFFSET 0x278
+#define AXI_RT_READ_BUDGET_LEFT_5_REG_OFFSET 0x1e8
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_6_REG_OFFSET 0x27c
+#define AXI_RT_READ_BUDGET_LEFT_6_REG_OFFSET 0x1ec
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_7_REG_OFFSET 0x280
+#define AXI_RT_READ_BUDGET_LEFT_7_REG_OFFSET 0x1f0
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_8_REG_OFFSET 0x284
+#define AXI_RT_READ_BUDGET_LEFT_8_REG_OFFSET 0x1f4
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_9_REG_OFFSET 0x288
+#define AXI_RT_READ_BUDGET_LEFT_9_REG_OFFSET 0x1f8
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_10_REG_OFFSET 0x28c
+#define AXI_RT_READ_BUDGET_LEFT_10_REG_OFFSET 0x1fc
 
 // The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_11_REG_OFFSET 0x290
-
-// The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_12_REG_OFFSET 0x294
-
-// The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_13_REG_OFFSET 0x298
-
-// The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_14_REG_OFFSET 0x29c
-
-// The budget left for reads.
-#define AXI_RT_READ_BUDGET_LEFT_15_REG_OFFSET 0x2a0
+#define AXI_RT_READ_BUDGET_LEFT_11_REG_OFFSET 0x200
 
 // The period left for writes. (common parameters)
 #define AXI_RT_WRITE_PERIOD_LEFT_WRITE_PERIOD_LEFT_FIELD_WIDTH 32
 #define AXI_RT_WRITE_PERIOD_LEFT_WRITE_PERIOD_LEFT_FIELDS_PER_REG 1
-#define AXI_RT_WRITE_PERIOD_LEFT_MULTIREG_COUNT 16
+#define AXI_RT_WRITE_PERIOD_LEFT_MULTIREG_COUNT 12
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_0_REG_OFFSET 0x2a4
+#define AXI_RT_WRITE_PERIOD_LEFT_0_REG_OFFSET 0x204
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_1_REG_OFFSET 0x2a8
+#define AXI_RT_WRITE_PERIOD_LEFT_1_REG_OFFSET 0x208
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_2_REG_OFFSET 0x2ac
+#define AXI_RT_WRITE_PERIOD_LEFT_2_REG_OFFSET 0x20c
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_3_REG_OFFSET 0x2b0
+#define AXI_RT_WRITE_PERIOD_LEFT_3_REG_OFFSET 0x210
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_4_REG_OFFSET 0x2b4
+#define AXI_RT_WRITE_PERIOD_LEFT_4_REG_OFFSET 0x214
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_5_REG_OFFSET 0x2b8
+#define AXI_RT_WRITE_PERIOD_LEFT_5_REG_OFFSET 0x218
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_6_REG_OFFSET 0x2bc
+#define AXI_RT_WRITE_PERIOD_LEFT_6_REG_OFFSET 0x21c
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_7_REG_OFFSET 0x2c0
+#define AXI_RT_WRITE_PERIOD_LEFT_7_REG_OFFSET 0x220
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_8_REG_OFFSET 0x2c4
+#define AXI_RT_WRITE_PERIOD_LEFT_8_REG_OFFSET 0x224
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_9_REG_OFFSET 0x2c8
+#define AXI_RT_WRITE_PERIOD_LEFT_9_REG_OFFSET 0x228
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_10_REG_OFFSET 0x2cc
+#define AXI_RT_WRITE_PERIOD_LEFT_10_REG_OFFSET 0x22c
 
 // The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_11_REG_OFFSET 0x2d0
-
-// The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_12_REG_OFFSET 0x2d4
-
-// The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_13_REG_OFFSET 0x2d8
-
-// The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_14_REG_OFFSET 0x2dc
-
-// The period left for writes.
-#define AXI_RT_WRITE_PERIOD_LEFT_15_REG_OFFSET 0x2e0
+#define AXI_RT_WRITE_PERIOD_LEFT_11_REG_OFFSET 0x230
 
 // The period left for reads. (common parameters)
 #define AXI_RT_READ_PERIOD_LEFT_READ_PERIOD_LEFT_FIELD_WIDTH 32
 #define AXI_RT_READ_PERIOD_LEFT_READ_PERIOD_LEFT_FIELDS_PER_REG 1
-#define AXI_RT_READ_PERIOD_LEFT_MULTIREG_COUNT 16
+#define AXI_RT_READ_PERIOD_LEFT_MULTIREG_COUNT 12
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_0_REG_OFFSET 0x2e4
+#define AXI_RT_READ_PERIOD_LEFT_0_REG_OFFSET 0x234
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_1_REG_OFFSET 0x2e8
+#define AXI_RT_READ_PERIOD_LEFT_1_REG_OFFSET 0x238
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_2_REG_OFFSET 0x2ec
+#define AXI_RT_READ_PERIOD_LEFT_2_REG_OFFSET 0x23c
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_3_REG_OFFSET 0x2f0
+#define AXI_RT_READ_PERIOD_LEFT_3_REG_OFFSET 0x240
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_4_REG_OFFSET 0x2f4
+#define AXI_RT_READ_PERIOD_LEFT_4_REG_OFFSET 0x244
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_5_REG_OFFSET 0x2f8
+#define AXI_RT_READ_PERIOD_LEFT_5_REG_OFFSET 0x248
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_6_REG_OFFSET 0x2fc
+#define AXI_RT_READ_PERIOD_LEFT_6_REG_OFFSET 0x24c
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_7_REG_OFFSET 0x300
+#define AXI_RT_READ_PERIOD_LEFT_7_REG_OFFSET 0x250
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_8_REG_OFFSET 0x304
+#define AXI_RT_READ_PERIOD_LEFT_8_REG_OFFSET 0x254
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_9_REG_OFFSET 0x308
+#define AXI_RT_READ_PERIOD_LEFT_9_REG_OFFSET 0x258
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_10_REG_OFFSET 0x30c
+#define AXI_RT_READ_PERIOD_LEFT_10_REG_OFFSET 0x25c
 
 // The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_11_REG_OFFSET 0x310
-
-// The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_12_REG_OFFSET 0x314
-
-// The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_13_REG_OFFSET 0x318
-
-// The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_14_REG_OFFSET 0x31c
-
-// The period left for reads.
-#define AXI_RT_READ_PERIOD_LEFT_15_REG_OFFSET 0x320
+#define AXI_RT_READ_PERIOD_LEFT_11_REG_OFFSET 0x260
 
 // Is the interface requested to be isolated? (common parameters)
 #define AXI_RT_ISOLATE_ISOLATE_FIELD_WIDTH 1
@@ -783,15 +623,13 @@ extern "C" {
 #define AXI_RT_ISOLATE_MULTIREG_COUNT 1
 
 // Is the interface requested to be isolated?
-#define AXI_RT_ISOLATE_REG_OFFSET 0x324
+#define AXI_RT_ISOLATE_REG_OFFSET 0x264
 #define AXI_RT_ISOLATE_ISOLATE_0_BIT 0
 #define AXI_RT_ISOLATE_ISOLATE_1_BIT 1
 #define AXI_RT_ISOLATE_ISOLATE_2_BIT 2
 #define AXI_RT_ISOLATE_ISOLATE_3_BIT 3
 #define AXI_RT_ISOLATE_ISOLATE_4_BIT 4
 #define AXI_RT_ISOLATE_ISOLATE_5_BIT 5
-#define AXI_RT_ISOLATE_ISOLATE_6_BIT 6
-#define AXI_RT_ISOLATE_ISOLATE_7_BIT 7
 
 // Is the interface isolated? (common parameters)
 #define AXI_RT_ISOLATED_ISOLATED_FIELD_WIDTH 1
@@ -799,48 +637,46 @@ extern "C" {
 #define AXI_RT_ISOLATED_MULTIREG_COUNT 1
 
 // Is the interface isolated?
-#define AXI_RT_ISOLATED_REG_OFFSET 0x328
+#define AXI_RT_ISOLATED_REG_OFFSET 0x268
 #define AXI_RT_ISOLATED_ISOLATED_0_BIT 0
 #define AXI_RT_ISOLATED_ISOLATED_1_BIT 1
 #define AXI_RT_ISOLATED_ISOLATED_2_BIT 2
 #define AXI_RT_ISOLATED_ISOLATED_3_BIT 3
 #define AXI_RT_ISOLATED_ISOLATED_4_BIT 4
 #define AXI_RT_ISOLATED_ISOLATED_5_BIT 5
-#define AXI_RT_ISOLATED_ISOLATED_6_BIT 6
-#define AXI_RT_ISOLATED_ISOLATED_7_BIT 7
 
 // Value of the num_managers parameter.
-#define AXI_RT_NUM_MANAGERS_REG_OFFSET 0x32c
+#define AXI_RT_NUM_MANAGERS_REG_OFFSET 0x26c
 
 // Value of the addr_width parameter.
-#define AXI_RT_ADDR_WIDTH_REG_OFFSET 0x330
+#define AXI_RT_ADDR_WIDTH_REG_OFFSET 0x270
 
 // Value of the data_width parameter.
-#define AXI_RT_DATA_WIDTH_REG_OFFSET 0x334
+#define AXI_RT_DATA_WIDTH_REG_OFFSET 0x274
 
 // Value of the id_width parameter.
-#define AXI_RT_ID_WIDTH_REG_OFFSET 0x338
+#define AXI_RT_ID_WIDTH_REG_OFFSET 0x278
 
 // Value of the user_width parameter.
-#define AXI_RT_USER_WIDTH_REG_OFFSET 0x33c
+#define AXI_RT_USER_WIDTH_REG_OFFSET 0x27c
 
 // Value of the num_pending parameter.
-#define AXI_RT_NUM_PENDING_REG_OFFSET 0x340
+#define AXI_RT_NUM_PENDING_REG_OFFSET 0x280
 
 // Value of the w_buffer_depth parameter.
-#define AXI_RT_W_BUFFER_DEPTH_REG_OFFSET 0x344
+#define AXI_RT_W_BUFFER_DEPTH_REG_OFFSET 0x284
 
 // Value of the num_addr_regions parameter.
-#define AXI_RT_NUM_ADDR_REGIONS_REG_OFFSET 0x348
+#define AXI_RT_NUM_ADDR_REGIONS_REG_OFFSET 0x288
 
 // Value of the period_width parameter.
-#define AXI_RT_PERIOD_WIDTH_REG_OFFSET 0x34c
+#define AXI_RT_PERIOD_WIDTH_REG_OFFSET 0x28c
 
 // Value of the budget_width parameter.
-#define AXI_RT_BUDGET_WIDTH_REG_OFFSET 0x350
+#define AXI_RT_BUDGET_WIDTH_REG_OFFSET 0x290
 
 // Value of the max_num_managers parameter.
-#define AXI_RT_MAX_NUM_MANAGERS_REG_OFFSET 0x354
+#define AXI_RT_MAX_NUM_MANAGERS_REG_OFFSET 0x294
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/include/util.h
+++ b/sw/include/util.h
@@ -88,53 +88,8 @@ static inline void *gprw(void *gp) {
 #define BIT(n) (1UL << (n))
 #define BIT_MASK(n) (BIT(n) - 1)
 
-// Check if an hardware feature is present from software
-static inline uint32_t hw_feature_present(uint32_t bit) {
+// Check if a hardware feature is present from software
+static inline uint32_t chs_hw_feature_present(uint32_t bit) {
     uint32_t features_bitmap = *reg32(&__base_regs, CHESHIRE_HW_FEATURES_REG_OFFSET);
-    return (features_bitmap & (1 << bit)) != 0;
-}
-
-// Helpers to handle Cheshire AXI managers attached to the system crossbar.
-
-// Cheshire managers. We label only core0 as the other cores - if any - are
-// contiguous after it by default.
-enum chs_mngrs {
-    CHS_MNGR_CORE0 = 0,
-    CHS_MNGR_DEBUG,
-    CHS_MNGR_DMA,
-    CHS_MNGR_SERIAL_LINK,
-    CHS_MNGR_VGA,
-    CHS_MNGR_USB
-};
-
-// Get Cheshire manager ID based on the hardware feature. If an hardware feature
-// is not implemented, returns `IMPL_ERR`.
-static inline uint32_t get_chs_mngr_id_from_hw_feature(enum chs_mngrs feature) {
-    uint32_t num_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
-    uint32_t current_id = num_harts;
-
-    // Determine ID based on the input feature
-    switch (feature) {
-    case CHS_MNGR_CORE0:
-        return 0; // Core 0 ID is always 0
-        break;
-    case CHS_MNGR_DEBUG:
-        return num_harts; // Debug ID is always after cores
-        break;
-    case CHS_MNGR_DMA:
-        return hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT) ? ++current_id : HW_IMPL_ERR;
-        break;
-    case CHS_MNGR_SERIAL_LINK:
-        return hw_feature_present(CHESHIRE_HW_FEATURES_SERIAL_LINK_BIT) ? ++current_id
-                                                                        : HW_IMPL_ERR;
-        break;
-    case CHS_MNGR_VGA:
-        return hw_feature_present(CHESHIRE_HW_FEATURES_VGA_BIT) ? ++current_id : HW_IMPL_ERR;
-        break;
-    case CHS_MNGR_USB:
-        return hw_feature_present(CHESHIRE_HW_FEATURES_USB_BIT) ? ++current_id : HW_IMPL_ERR;
-        break;
-    default:
-        return HW_IMPL_ERR; // Unknown feature
-    }
+    return (features_bitmap & BIT(bit)) != 0;
 }

--- a/sw/include/util.h
+++ b/sw/include/util.h
@@ -5,10 +5,13 @@
 // Nicole Narr <narrn@student.ethz.ch>
 // Christopher Reinwardt <creinwar@student.ethz.ch>
 // Paul Scheffler <paulsc@iis.ee.ethz.ch>
+// Alessandro Ottaviano <aottaviano@iis.ee.ethz.ch>
 
 #pragma once
 
 #include <stdint.h>
+#include "regs/cheshire.h"
+#include "params.h"
 
 static inline volatile uint8_t *reg8(void *base, int offs) {
     return (volatile uint8_t *)(base + offs);
@@ -75,8 +78,63 @@ static inline void *gprw(void *gp) {
         if (__ccret) return __ccret; \
     }
 
-// If a condition; if it is untrue, ummediately return an error code.
+// If a condition; if it is untrue, immediately return an error code.
 #define CHECK_ASSERT(ret, cond) \
     if (!(cond)) return (ret);
 
 #define MIN(a, b) (((a) <= (b)) ? (a) : (b))
+
+// Bit manipulation
+#define BIT(n) (1UL << (n))
+#define BIT_MASK(n) (BIT(n) - 1)
+
+// Check if an hardware feature is present from software
+static inline uint32_t hw_feature_present(uint32_t bit) {
+    uint32_t features_bitmap = *reg32(&__base_regs, CHESHIRE_HW_FEATURES_REG_OFFSET);
+    return (features_bitmap & (1 << bit)) != 0;
+}
+
+// Helpers to handle Cheshire AXI managers attached to the system crossbar.
+
+// Cheshire managers. We label only core0 as the other cores - if any - are
+// contiguous after it by default.
+enum chs_mngrs {
+    CHS_MNGR_CORE0 = 0,
+    CHS_MNGR_DEBUG,
+    CHS_MNGR_DMA,
+    CHS_MNGR_SERIAL_LINK,
+    CHS_MNGR_VGA,
+    CHS_MNGR_USB
+};
+
+// Get Cheshire manager ID based on the hardware feature. If an hardware feature
+// is not implemented, returns `IMPL_ERR`.
+static inline uint32_t get_chs_mngr_id_from_hw_feature(enum chs_mngrs feature) {
+    uint32_t num_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
+    uint32_t current_id = num_harts;
+
+    // Determine ID based on the input feature
+    switch (feature) {
+    case CHS_MNGR_CORE0:
+        return 0; // Core 0 ID is always 0
+        break;
+    case CHS_MNGR_DEBUG:
+        return num_harts; // Debug ID is always after cores
+        break;
+    case CHS_MNGR_DMA:
+        return hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT) ? ++current_id : HW_IMPL_ERR;
+        break;
+    case CHS_MNGR_SERIAL_LINK:
+        return hw_feature_present(CHESHIRE_HW_FEATURES_SERIAL_LINK_BIT) ? ++current_id
+                                                                        : HW_IMPL_ERR;
+        break;
+    case CHS_MNGR_VGA:
+        return hw_feature_present(CHESHIRE_HW_FEATURES_VGA_BIT) ? ++current_id : HW_IMPL_ERR;
+        break;
+    case CHS_MNGR_USB:
+        return hw_feature_present(CHESHIRE_HW_FEATURES_USB_BIT) ? ++current_id : HW_IMPL_ERR;
+        break;
+    default:
+        return HW_IMPL_ERR; // Unknown feature
+    }
+}

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -93,7 +93,7 @@ int main(void) {
                           DMA_DST_STRIDE, DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Check DMA transfers against gold.
-    for (volatile int i = 0; i < DMA_NUM_BEATS; i++) {
+    for (int i = 0; i < DMA_NUM_BEATS; i++) {
         CHECK_ASSERT(20, dma_dst[i] == golden[i]);
     }
 

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -89,7 +89,7 @@ int main(void) {
     }
 
     // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uintptr_t)dma_dst, (uintptr_t)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
+    sys_dma_2d_blk_memcpy((uintptr_t)(void*)dma_dst, (uintptr_t)(void*)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
                           DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Check DMA transfers against gold.

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -26,7 +26,8 @@
 #define DMA_SRC_ADDRESS 0x10008000
 #define DMA_DST_ADDRESS 0x80008000
 
-// AXI-REALM
+// AXI-REALM (IDs assume default config; adapt as needed)
+#define CVA6_BASE_MGR_ID 0
 #define CVA6_ALLOCATED_BUDGET 0x10000000
 #define CVA6_ALLOCATED_PERIOD 0x10000000
 #define DMA_ALLOCATED_BUDGET 0x10000000
@@ -35,6 +36,9 @@
 
 int main(void) {
 
+    // Immediately return an error if DMA is not present in cheshire
+    CHECK_ASSERT(-1, !chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
+
     uint32_t cheshire_num_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
 
     volatile uint64_t *dma_src = (volatile uint64_t *)(DMA_SRC_ADDRESS);
@@ -42,15 +46,14 @@ int main(void) {
 
     uint64_t golden[DMA_NUM_BEATS]; // Declare non-volatile array for golden values
 
-    // enable and configure axi rt
+    // Enable and configure axi rt
     __axirt_claim(1, 1);
     __axirt_set_len_limit_group(FRAGMENTATION_SIZE_BEATS, 0);
     __axirt_set_len_limit_group(FRAGMENTATION_SIZE_BEATS, 1);
     fence();
 
-    // configure RT unit for all the CVA6 cores
-    uint32_t chs_core0_id = get_chs_mngr_id_from_hw_feature(CHS_MNGR_CORE0);
-    for (uint32_t id = chs_core0_id; id < cheshire_num_harts; id++) {
+    // Configure RT unit for all the CVA6 cores
+    for (uint32_t id = CVA6_BASE_MGR_ID; id < cheshire_num_harts; id++) {
         __axirt_set_region(0, 0xffffffff, 0, id);
         __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, id);
         __axirt_set_budget(CVA6_ALLOCATED_BUDGET, 0, id);
@@ -60,10 +63,8 @@ int main(void) {
         fence();
     }
 
-    // configure RT unit for the DMA
-    uint32_t chs_dma_id = get_chs_mngr_id_from_hw_feature(CHS_MNGR_DMA);
-    // Immediately return an error if DMA is not present in cheshire
-    CHECK_ASSERT(HW_IMPL_ERR, (chs_dma_id != HW_IMPL_ERR));
+    // Configure RT unit for the DMA
+    uint32_t chs_dma_id = CVA6_BASE_MGR_ID + cheshire_num_harts + 1;
 
     __axirt_set_region(0, 0xffffffff, 0, chs_dma_id);
     __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, chs_dma_id);
@@ -73,21 +74,21 @@ int main(void) {
     __axirt_set_period(DMA_ALLOCATED_PERIOD, 1, chs_dma_id);
     fence();
 
-    // enable RT unit for all the cores
+    // Enable RT unit for all the cores
     __axirt_enable(BIT_MASK(cheshire_num_harts));
 
-    // enable RT unit for the DMA
+    // Enable RT unit for the DMA
     __axirt_enable(BIT(chs_dma_id));
     fence();
 
-    // initialize src region and golden values
+    // Initialize src region and golden values
     for (int i = 0; i < DMA_NUM_BEATS; i++) {
         golden[i] = 0xcafedeadbaadf00dULL + i; // Compute golden values
         dma_src[i] = golden[i];                // Initialize source memory
         fence();
     }
 
-    // launch blocking DMA transfer
+    // Launch blocking DMA transfer
     sys_dma_2d_blk_memcpy((uint64_t *)dma_dst, (uint64_t *)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
                           DMA_SRC_STRIDE, DMA_NUM_REPS);
 
@@ -96,19 +97,19 @@ int main(void) {
         CHECK_ASSERT(20, dma_dst[i] == golden[i]);
     }
 
-    // read budget registers for dma and compare
+    // Read budget registers for dma and compare
     volatile uint32_t dma_read_budget_left =
         *reg32(&__base_axirt, AXI_RT_READ_BUDGET_LEFT_4_REG_OFFSET);
     volatile uint32_t dma_write_budget_left =
         *reg32(&__base_axirt, AXI_RT_WRITE_BUDGET_LEFT_4_REG_OFFSET);
 
-    // check budget: return 0 if (initial budget - final budget) matches the
+    // Check budget: return 0 if (initial budget - final budget) matches the
     // number of transferred bytes, otherwise return 1
     volatile uint8_t dma_r_difference =
         (DMA_ALLOCATED_BUDGET - dma_read_budget_left) != DMA_TOTAL_SIZE_BYTES;
     volatile uint8_t dma_w_difference =
         (DMA_ALLOCATED_BUDGET - dma_write_budget_left) != DMA_TOTAL_SIZE_BYTES;
-    // w and r are symmetric on the dma: left budgets should be equal
+    // W and R are symmetric on the dma: left budgets should be equal
     volatile uint8_t dma_rw_mismatch = dma_read_budget_left != dma_write_budget_left;
 
     return (dma_rw_mismatch | dma_r_difference | dma_w_difference);

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -86,17 +86,19 @@ int main(void) {
 
     // Wait for writes, then launch blocking DMA transfer
     fence();
-    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, sizeof(golden),
-                          0, 0, 1);
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, sizeof(golden), 0,
+                          0, 1);
 
     // Check DMA transfers against gold.
     for (int i = 0; i < DMA_NUM_BEATS; i++) CHECK_ASSERT(20 + i, dma_dst[i] == golden[i]);
 
     // Read budget registers for dma and compare
-    int dma_read_budget_left = *reg32(&__base_axirt, AXI_RT_READ_BUDGET_LEFT_0_REG_OFFSET
-        + AXI_RT_PARAM_NUM_SUB * chs_dma_id * sizeof(uint32_t));
-    int dma_write_budget_left = *reg32(&__base_axirt, AXI_RT_WRITE_BUDGET_LEFT_0_REG_OFFSET
-        + AXI_RT_PARAM_NUM_SUB * chs_dma_id * sizeof(uint32_t));
+    int dma_read_budget_left =
+        *reg32(&__base_axirt, AXI_RT_READ_BUDGET_LEFT_0_REG_OFFSET +
+                                  AXI_RT_PARAM_NUM_SUB * chs_dma_id * sizeof(uint32_t));
+    int dma_write_budget_left =
+        *reg32(&__base_axirt, AXI_RT_WRITE_BUDGET_LEFT_0_REG_OFFSET +
+                                  AXI_RT_PARAM_NUM_SUB * chs_dma_id * sizeof(uint32_t));
 
     // Check budget: return 0 if (initial budget - final budget) matches the
     // number of transferred bytes, otherwise return 1

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -89,8 +89,8 @@ int main(void) {
     }
 
     // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
-                          DMA_SRC_STRIDE, DMA_NUM_REPS);
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, DMA_SIZE_BYTES,
+                          DMA_DST_STRIDE, DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Check DMA transfers against gold.
     for (volatile int i = 0; i < DMA_NUM_BEATS; i++) {

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -13,38 +13,36 @@
 #include "regs/axi_rt.h"
 #include "regs/cheshire.h"
 #include "util.h"
-#include "printf.h"
 
-// transfer
-#define SIZE_BEAT_BYTES 8
-#define DMA_NUM_BEATS 128
-#define DMA_NUM_REPS 1
-#define DMA_SIZE_BYTES (SIZE_BEAT_BYTES * DMA_NUM_BEATS)
-#define DMA_TOTAL_SIZE_BYTES (DMA_SIZE_BYTES * DMA_NUM_REPS)
-#define DMA_SRC_STRIDE 0
-#define DMA_DST_STRIDE 0
-#define DMA_SRC_ADDRESS 0x10008000
-#define DMA_DST_ADDRESS 0x80008000
-
-// AXI-REALM (IDs assume default config; adapt as needed)
 #define CVA6_BASE_MGR_ID 0
 #define CVA6_ALLOCATED_BUDGET 0x10000000
 #define CVA6_ALLOCATED_PERIOD 0x10000000
+#define DMA_NUM_BEATS 128 // We assume 64b AXI data width here
 #define DMA_ALLOCATED_BUDGET 0x10000000
 #define DMA_ALLOCATED_PERIOD 0x10000000
 #define FRAGMENTATION_SIZE_BEATS 0 // Max fragmentation applied to bursts
 
 int main(void) {
+    // Immediately return an error if AXI_REALM or DMA are not present
+    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_AXIRT_BIT));
+    CHECK_ASSERT(-2, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
 
-    // Immediately return an error if DMA is not present in cheshire
-    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
+    // This test requires at least two subordinate regions
+    CHECK_ASSERT(-3, AXI_RT_PARAM_NUM_SUB >= 2);
 
-    uint32_t cheshire_num_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
+    // Get internal hart count
+    int num_int_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
 
-    volatile uint64_t *dma_src = (volatile uint64_t *)(DMA_SRC_ADDRESS);
-    volatile uint64_t *dma_dst = (volatile uint64_t *)(DMA_DST_ADDRESS);
+    // Allocate DMA buffers
+    volatile uint64_t dma_src_cached[DMA_NUM_BEATS];
+    volatile uint64_t dma_dst_cached[DMA_NUM_BEATS];
 
-    uint64_t golden[DMA_NUM_BEATS]; // Declare non-volatile array for golden values
+    // Use pointers to uncached buffers allocated in SPM
+    volatile uint64_t *dma_src = dma_src_cached + (0x04000000 / sizeof(uint64_t));
+    volatile uint64_t *dma_dst = dma_dst_cached + (0x04000000 / sizeof(uint64_t));
+
+    // Declare non-volatile array for golden values
+    uint64_t golden[DMA_NUM_BEATS];
 
     // Enable and configure axi rt
     __axirt_claim(1, 1);
@@ -53,7 +51,7 @@ int main(void) {
     fence();
 
     // Configure RT unit for all the CVA6 cores
-    for (uint32_t id = CVA6_BASE_MGR_ID; id < cheshire_num_harts; id++) {
+    for (int id = CVA6_BASE_MGR_ID; id < num_int_harts; id++) {
         __axirt_set_region(0, 0xffffffff, 0, id);
         __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, id);
         __axirt_set_budget(CVA6_ALLOCATED_BUDGET, 0, id);
@@ -64,8 +62,7 @@ int main(void) {
     }
 
     // Configure RT unit for the DMA
-    uint32_t chs_dma_id = CVA6_BASE_MGR_ID + cheshire_num_harts + 1;
-
+    int chs_dma_id = CVA6_BASE_MGR_ID + num_int_harts + 1;
     __axirt_set_region(0, 0xffffffff, 0, chs_dma_id);
     __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, chs_dma_id);
     __axirt_set_budget(DMA_ALLOCATED_BUDGET, 0, chs_dma_id);
@@ -75,7 +72,7 @@ int main(void) {
     fence();
 
     // Enable RT unit for all the cores
-    __axirt_enable(BIT_MASK(cheshire_num_harts));
+    __axirt_enable(BIT_MASK(num_int_harts));
 
     // Enable RT unit for the DMA
     __axirt_enable(BIT(chs_dma_id));
@@ -85,32 +82,28 @@ int main(void) {
     for (int i = 0; i < DMA_NUM_BEATS; i++) {
         golden[i] = 0xcafedeadbaadf00dULL + i; // Compute golden values
         dma_src[i] = golden[i];                // Initialize source memory
-        fence();
     }
 
-    // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, DMA_SIZE_BYTES,
-                          DMA_DST_STRIDE, DMA_SRC_STRIDE, DMA_NUM_REPS);
+    // Wait for writes, then launch blocking DMA transfer
+    fence();
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, sizeof(golden),
+                          0, 0, 1);
 
     // Check DMA transfers against gold.
-    for (int i = 0; i < DMA_NUM_BEATS; i++) {
-        CHECK_ASSERT(20, dma_dst[i] == golden[i]);
-    }
+    for (int i = 0; i < DMA_NUM_BEATS; i++) CHECK_ASSERT(20 + i, dma_dst[i] == golden[i]);
 
     // Read budget registers for dma and compare
-    volatile uint32_t dma_read_budget_left =
-        *reg32(&__base_axirt, AXI_RT_READ_BUDGET_LEFT_4_REG_OFFSET);
-    volatile uint32_t dma_write_budget_left =
-        *reg32(&__base_axirt, AXI_RT_WRITE_BUDGET_LEFT_4_REG_OFFSET);
+    int dma_read_budget_left = *reg32(&__base_axirt, AXI_RT_READ_BUDGET_LEFT_0_REG_OFFSET
+        + AXI_RT_PARAM_NUM_SUB * chs_dma_id * sizeof(uint32_t));
+    int dma_write_budget_left = *reg32(&__base_axirt, AXI_RT_WRITE_BUDGET_LEFT_0_REG_OFFSET
+        + AXI_RT_PARAM_NUM_SUB * chs_dma_id * sizeof(uint32_t));
 
     // Check budget: return 0 if (initial budget - final budget) matches the
     // number of transferred bytes, otherwise return 1
-    volatile uint8_t dma_r_difference =
-        (DMA_ALLOCATED_BUDGET - dma_read_budget_left) != DMA_TOTAL_SIZE_BYTES;
-    volatile uint8_t dma_w_difference =
-        (DMA_ALLOCATED_BUDGET - dma_write_budget_left) != DMA_TOTAL_SIZE_BYTES;
+    int dma_r_difference = (DMA_ALLOCATED_BUDGET - dma_read_budget_left) != sizeof(golden);
+    int dma_w_difference = (DMA_ALLOCATED_BUDGET - dma_write_budget_left) != sizeof(golden);
     // W and R are symmetric on the dma: left budgets should be equal
-    volatile uint8_t dma_rw_mismatch = dma_read_budget_left != dma_write_budget_left;
+    int dma_rw_mismatch = dma_read_budget_left != dma_write_budget_left;
 
-    return (dma_rw_mismatch | dma_r_difference | dma_w_difference);
+    return dma_rw_mismatch + dma_r_difference + dma_w_difference;
 }

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -89,7 +89,7 @@ int main(void) {
     }
 
     // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uint64_t *)dma_dst, (uint64_t *)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
+    sys_dma_2d_blk_memcpy((uintptr_t)dma_dst, (uintptr_t)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
                           DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Check DMA transfers against gold.

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -89,7 +89,7 @@ int main(void) {
     }
 
     // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uintptr_t)(void*)dma_dst, (uintptr_t)(void*)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
                           DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Check DMA transfers against gold.

--- a/sw/tests/axirt_budget.c
+++ b/sw/tests/axirt_budget.c
@@ -37,7 +37,7 @@
 int main(void) {
 
     // Immediately return an error if DMA is not present in cheshire
-    CHECK_ASSERT(-1, !chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
+    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
 
     uint32_t cheshire_num_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
 

--- a/sw/tests/axirt_budget_isolate.c
+++ b/sw/tests/axirt_budget_isolate.c
@@ -35,7 +35,6 @@
 #define DMA_ALLOCATED_PERIOD 0x10000000
 #define FRAGMENTATION_SIZE_BEATS 0 // Max fragmentation applied to bursts
 
-
 int main(void) {
 
     // Immediately return an error if DMA is not present in cheshire

--- a/sw/tests/axirt_budget_isolate.c
+++ b/sw/tests/axirt_budget_isolate.c
@@ -87,7 +87,7 @@ int main(void) {
     }
 
     // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uintptr_t)(void*)dma_dst, (uintptr_t)(void*)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
                           DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Poll isolate to check if AXI-REALM isolates the dma when the budget is

--- a/sw/tests/axirt_budget_isolate.c
+++ b/sw/tests/axirt_budget_isolate.c
@@ -38,7 +38,7 @@
 int main(void) {
 
     // Immediately return an error if DMA is not present in cheshire
-    CHECK_ASSERT(-1, !chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
+    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
 
     uint32_t cheshire_num_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
 

--- a/sw/tests/axirt_budget_isolate.c
+++ b/sw/tests/axirt_budget_isolate.c
@@ -87,7 +87,7 @@ int main(void) {
     }
 
     // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uint64_t *)dma_dst, (uint64_t *)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
+    sys_dma_2d_blk_memcpy((uintptr_t)dma_dst, (uintptr_t)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
                           DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Poll isolate to check if AXI-REALM isolates the dma when the budget is

--- a/sw/tests/axirt_budget_isolate.c
+++ b/sw/tests/axirt_budget_isolate.c
@@ -87,8 +87,8 @@ int main(void) {
     }
 
     // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
-                          DMA_SRC_STRIDE, DMA_NUM_REPS);
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, DMA_SIZE_BYTES,
+                          DMA_DST_STRIDE, DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Poll isolate to check if AXI-REALM isolates the dma when the budget is
     // exceeded. Should return 1 if dma is isolated.

--- a/sw/tests/axirt_budget_isolate.c
+++ b/sw/tests/axirt_budget_isolate.c
@@ -13,37 +13,35 @@
 #include "regs/cheshire.h"
 #include "util.h"
 
-// Transfer
-#define SIZE_BEAT_BYTES 8
-#define DMA_NUM_BEATS 32
-#define DMA_NUM_REPS 8
-#define DMA_SIZE_BYTES (SIZE_BEAT_BYTES * DMA_NUM_BEATS)
-#define DMA_TOTAL_SIZE_BYTES (DMA_SIZE_BYTES * DMA_NUM_REPS)
-#define DMA_SRC_STRIDE 0
-#define DMA_DST_STRIDE 0
-#define DMA_SRC_ADDRESS 0x10008000
-#define DMA_DST_ADDRESS 0x80008000
-
-// AXI-REALM (IDs assume default config; adapt as needed)
 #define CVA6_BASE_MGR_ID 0
 #define CVA6_ALLOCATED_BUDGET 0x10000000
 #define CVA6_ALLOCATED_PERIOD 0x10000000
-#define DMA_ALLOCATED_BUDGET \
-    (DMA_TOTAL_SIZE_BYTES / 2) // Set budget as half of the number of bytes to
-                               // transfer. This is done intentionally to test
-                               // isolation capabilities.
+#define DMA_NUM_BEATS 32 // We assume 64b AXI data width here
+#define DMA_NUM_REPS 8
+// Set DMA budget as half of the number of bytes to transfer.
+// This is done intentionally to test isolation capabilities.
+#define DMA_ALLOCATED_BUDGET (8 * DMA_NUM_BEATS * DMA_NUM_REPS / 2)
 #define DMA_ALLOCATED_PERIOD 0x10000000
 #define FRAGMENTATION_SIZE_BEATS 0 // Max fragmentation applied to bursts
 
 int main(void) {
+    // Immediately return an error if AXI_REALM or DMA are not present
+    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_AXIRT_BIT));
+    CHECK_ASSERT(-2, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
 
-    // Immediately return an error if DMA is not present in cheshire
-    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
+    // This test requires at least two subordinate regions
+    CHECK_ASSERT(-3, AXI_RT_PARAM_NUM_SUB >= 2);
 
-    uint32_t cheshire_num_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
+    // Get internal hart count
+    int num_int_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
 
-    volatile uint64_t *dma_src = (volatile uint64_t *)(DMA_SRC_ADDRESS);
-    volatile uint64_t *dma_dst = (volatile uint64_t *)(DMA_DST_ADDRESS);
+    // Allocate DMA buffers
+    volatile uint64_t dma_src_cached[DMA_NUM_BEATS];
+    volatile uint64_t dma_dst_cached[DMA_NUM_BEATS];
+
+    // Use pointers to uncached buffers allocated in SPM
+    volatile uint64_t *dma_src = dma_src_cached + (0x04000000 / sizeof(uint64_t));
+    volatile uint64_t *dma_dst = dma_dst_cached + (0x04000000 / sizeof(uint64_t));
 
     // Enable and configure axi rt
     __axirt_claim(1, 1);
@@ -52,7 +50,7 @@ int main(void) {
     fence();
 
     // Configure RT unit for all the CVA6 cores (adapt ID if needed).
-    for (uint32_t id = CVA6_BASE_MGR_ID; id < cheshire_num_harts; id++) {
+    for (int id = CVA6_BASE_MGR_ID; id < num_int_harts; id++) {
         __axirt_set_region(0, 0xffffffff, 0, id);
         __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, id);
         __axirt_set_budget(CVA6_ALLOCATED_BUDGET, 0, id);
@@ -63,8 +61,7 @@ int main(void) {
     }
 
     // Configure RT unit for the DMA
-    uint32_t chs_dma_id = CVA6_BASE_MGR_ID + cheshire_num_harts + 1;
-
+    int chs_dma_id = CVA6_BASE_MGR_ID + num_int_harts + 1;
     __axirt_set_region(0, 0xffffffff, 0, chs_dma_id);
     __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, chs_dma_id);
     __axirt_set_budget(DMA_ALLOCATED_BUDGET, 0, chs_dma_id);
@@ -74,25 +71,23 @@ int main(void) {
     fence();
 
     // Enable RT unit for all the cores
-    __axirt_enable(BIT_MASK(cheshire_num_harts));
+    __axirt_enable(BIT_MASK(num_int_harts));
 
     // Enable RT unit for the DMA
     __axirt_enable(BIT(chs_dma_id));
     fence();
 
     // Initialize src region and golden values
-    for (int i = 0; i < DMA_NUM_BEATS; i++) {
-        dma_src[i] = 0xcafedeadbaadf00dULL + i;
-        fence();
-    }
+    for (int i = 0; i < DMA_NUM_BEATS; i++) dma_src[i] = 0xcafedeadbaadf00dULL + i;
 
-    // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, DMA_SIZE_BYTES,
-                          DMA_DST_STRIDE, DMA_SRC_STRIDE, DMA_NUM_REPS);
+    // Wait for writes, then launch blocking DMA transfer
+    fence();
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src,
+                          sizeof(dma_src_cached), 0, 0, DMA_NUM_REPS);
 
     // Poll isolate to check if AXI-REALM isolates the dma when the budget is
     // exceeded. Should return 1 if dma is isolated.
-    uint8_t isolate_status = __axirt_poll_isolate(chs_dma_id);
+    int isolate_status = __axirt_poll_isolate(chs_dma_id);
 
     // Return 0 if manager was correctly isolated
     return !isolate_status;

--- a/sw/tests/axirt_budget_isolate.c
+++ b/sw/tests/axirt_budget_isolate.c
@@ -87,7 +87,7 @@ int main(void) {
     }
 
     // Launch blocking DMA transfer
-    sys_dma_2d_blk_memcpy((uintptr_t)dma_dst, (uintptr_t)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
+    sys_dma_2d_blk_memcpy((uintptr_t)(void*)dma_dst, (uintptr_t)(void*)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
                           DMA_SRC_STRIDE, DMA_NUM_REPS);
 
     // Poll isolate to check if AXI-REALM isolates the dma when the budget is

--- a/sw/tests/axirt_budget_isolate.c
+++ b/sw/tests/axirt_budget_isolate.c
@@ -1,0 +1,99 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Alessandro Ottaviano <aottaviano@iis.ee.ethz.ch>
+//
+// Validate the isolation functionality of AXI-REALM
+
+#include "axirt.h"
+#include "dif/dma.h"
+#include "params.h"
+#include "regs/axi_rt.h"
+#include "regs/cheshire.h"
+#include "util.h"
+
+// transfer
+#define SIZE_BEAT_BYTES 8
+#define DMA_NUM_BEATS 32
+#define DMA_NUM_REPS 8
+#define DMA_SIZE_BYTES (SIZE_BEAT_BYTES * DMA_NUM_BEATS)
+#define DMA_TOTAL_SIZE_BYTES (DMA_SIZE_BYTES * DMA_NUM_REPS)
+#define DMA_SRC_STRIDE 0
+#define DMA_DST_STRIDE 0
+#define DMA_SRC_ADDRESS 0x10008000
+#define DMA_DST_ADDRESS 0x80008000
+
+// AXI-REALM
+#define CVA6_ALLOCATED_BUDGET 0x10000000
+#define CVA6_ALLOCATED_PERIOD 0x10000000
+#define DMA_ALLOCATED_BUDGET \
+    (DMA_TOTAL_SIZE_BYTES / 2) // Set budget as half of the number of bytes to
+                               // transfer. This is done intentionally to test
+                               // isolation capabilities.
+#define DMA_ALLOCATED_PERIOD 0x10000000
+#define FRAGMENTATION_SIZE_BEATS 0 // Max fragmentation applied to bursts
+
+int main(void) {
+
+    uint32_t cheshire_num_harts = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET);
+
+    volatile uint64_t *dma_src = (volatile uint64_t *)(DMA_SRC_ADDRESS);
+    volatile uint64_t *dma_dst = (volatile uint64_t *)(DMA_DST_ADDRESS);
+
+    // enable and configure axi rt
+    __axirt_claim(1, 1);
+    __axirt_set_len_limit_group(FRAGMENTATION_SIZE_BEATS, 0);
+    __axirt_set_len_limit_group(FRAGMENTATION_SIZE_BEATS, 1);
+    fence();
+
+    // configure RT unit for all the CVA6 cores. At least one RV64 core is
+    // always present, so no need to check if the feature is there or not.
+    uint32_t chs_core0_id = get_chs_mngr_id_from_hw_feature(CHS_MNGR_CORE0);
+    for (uint32_t id = chs_core0_id; id < cheshire_num_harts; id++) {
+        __axirt_set_region(0, 0xffffffff, 0, id);
+        __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, id);
+        __axirt_set_budget(CVA6_ALLOCATED_BUDGET, 0, id);
+        __axirt_set_budget(CVA6_ALLOCATED_BUDGET, 1, id);
+        __axirt_set_period(CVA6_ALLOCATED_PERIOD, 0, id);
+        __axirt_set_period(CVA6_ALLOCATED_PERIOD, 1, id);
+        fence();
+    }
+
+    // configure RT unit for the DMA
+    uint32_t chs_dma_id = get_chs_mngr_id_from_hw_feature(CHS_MNGR_DMA);
+    // immediately return an error if DMA is not present in cheshire
+    CHECK_ASSERT(HW_IMPL_ERR, (chs_dma_id != HW_IMPL_ERR));
+
+    __axirt_set_region(0, 0xffffffff, 0, chs_dma_id);
+    __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, chs_dma_id);
+    __axirt_set_budget(DMA_ALLOCATED_BUDGET, 0, chs_dma_id);
+    __axirt_set_budget(DMA_ALLOCATED_BUDGET, 1, chs_dma_id);
+    __axirt_set_period(DMA_ALLOCATED_PERIOD, 0, chs_dma_id);
+    __axirt_set_period(DMA_ALLOCATED_PERIOD, 1, chs_dma_id);
+    fence();
+
+    // enable RT unit for all the cores
+    __axirt_enable(BIT_MASK(cheshire_num_harts));
+
+    // enable RT unit for the DMA
+    __axirt_enable(BIT(chs_dma_id));
+    fence();
+
+    // initialize src region and golden values
+    for (int i = 0; i < DMA_NUM_BEATS; i++) {
+        dma_src[i] = 0xcafedeadbaadf00dULL + i;
+        fence();
+    }
+
+    // launch blocking DMA transfer
+    sys_dma_2d_blk_memcpy((uint64_t *)dma_dst, (uint64_t *)dma_src, DMA_SIZE_BYTES, DMA_DST_STRIDE,
+                          DMA_SRC_STRIDE, DMA_NUM_REPS);
+
+    // poll isolate to check if AXI-REALM isolates the dma when the budget is
+    // exceeded. Should return 1 if dma is isolated.
+    uint8_t isolate_status = __axirt_poll_isolate(chs_dma_id);
+
+    // return 0 if manager was correctly isolated
+    return !isolate_status;
+}

--- a/sw/tests/axirt_hello.c
+++ b/sw/tests/axirt_hello.c
@@ -17,6 +17,14 @@
 #include "util.h"
 
 int main(void) {
+    // Immediately return an error if AXI_REALM, DMA, or UART are not present
+    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_AXIRT_BIT));
+    CHECK_ASSERT(-2, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
+    CHECK_ASSERT(-3, chs_hw_feature_present(CHESHIRE_HW_FEATURES_UART_BIT));
+
+    // This test requires at least two subordinate regions
+    CHECK_ASSERT(-4, AXI_RT_PARAM_NUM_SUB >= 2);
+
     char str[] = "Hello AXI-RT!\r\n";
     uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
     uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);

--- a/sw/tests/axirt_hello.c
+++ b/sw/tests/axirt_hello.c
@@ -29,11 +29,11 @@ int main(void) {
     uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
     uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
 
-    // enable and configure axi rt
+    // Enable and configure AXI REALM
     __axirt_claim(1, 1);
     __axirt_set_len_limit_group(2, 0);
 
-    // configure CVA6
+    // Configure CVA6 core 0
     __axirt_set_region(0, 0xffffffff, 0, 0);
     __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, 0);
     __axirt_set_budget(8, 0, 0);
@@ -41,19 +41,20 @@ int main(void) {
     __axirt_set_period(100, 0, 0);
     __axirt_set_period(100, 1, 0);
 
-    // configure DMA
-    __axirt_set_region(0, 0xffffffff, 0, 2);
-    __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, 2);
-    __axirt_set_budget(0x10000000, 0, 2);
-    __axirt_set_budget(0x10000000, 1, 2);
-    __axirt_set_period(0x10000000, 0, 2);
-    __axirt_set_period(0x10000000, 1, 2);
+    // Configure DMA
+    int chs_dma_id = *reg32(&__base_regs, CHESHIRE_NUM_INT_HARTS_REG_OFFSET) + 1;
+    __axirt_set_region(0, 0xffffffff, 0, chs_dma_id);
+    __axirt_set_region(0x100000000, 0xffffffffffffffff, 1, chs_dma_id);
+    __axirt_set_budget(0x10000000, 0, chs_dma_id);
+    __axirt_set_budget(0x10000000, 1, chs_dma_id);
+    __axirt_set_period(0x10000000, 0, chs_dma_id);
+    __axirt_set_period(0x10000000, 1, chs_dma_id);
 
-    // enable RT unit for DMA and CVA6
+    // Enable RT unit for DMA and CVA6 core 0
     __axirt_enable(0x5);
 
-    // configure uart and write msg
-    uart_init(&__base_uart, reset_freq, 115200);
+    // Configure UART and write message
+    uart_init(&__base_uart, reset_freq, __BOOT_BAUDRATE);
     uart_write_str(&__base_uart, str, sizeof(str));
     uart_write_flush(&__base_uart);
     return 0;

--- a/sw/tests/dma_2d.c
+++ b/sw/tests/dma_2d.c
@@ -11,6 +11,9 @@
 #include "dif/dma.h"
 
 int main(void) {
+    // Immediately return an error if DMA is not present
+    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
+
     volatile char src_cached[] = "This is a DMA test";
     volatile char gold[] = "This ishis is is is as is a DMA test!";
 


### PR DESCRIPTION
* Bump AXI-REALM to latest version. Fixes functional bug in the write buffer module (https://github.com/pulp-platform/axi_rt/pull/11).

* Fix default number of configuration registers in `cheshire.mk`

* Fix budget (W/R) left check in `axirt_budget.c` test

* Add `axirt_budget_isolation.c` test to check manager isolation through AXI-REALM after budget expires (transfer size > budget)

* Further additions: 
  * Fix `tclint` version to 0.4.2
  * Fix `CHSROOT` to static `realpath` (`pwd` may not be a fully qualified path)
  * Check for used features in all non-`helloworld` tests
