### PR TITLE
treewide: Connect LLC performance counters to cheshire regs

### DIFF
--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -550,7 +550,9 @@ package cheshire_pkg;
       RefillWrite    = 4,
       RefillRead     = 5,
       EvictWrite     = 6,
-      EvictRead      = 7
+      EvictRead      = 7,
+      WAccess        = 8,
+      RAccess        = 9
   } llc_evts_e;
 
   ////////////////

--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -537,6 +537,22 @@ package cheshire_pkg;
     };
   endfunction
 
+  ///////////
+  //  LLC  //
+  ///////////
+
+  // LLC performance counter events.
+  typedef enum word_bt {
+      HitWriteCache  = 0,
+      HitReadCache   = 1,
+      MissWriteCache = 2,
+      MissReadCache  = 3,
+      RefillWrite    = 4,
+      RefillRead     = 5,
+      EvictWrite     = 6,
+      EvictRead      = 7
+  } llc_evts_e;
+
   ////////////////
   //  Defaults  //
   ////////////////

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -437,7 +437,7 @@ module cheshire_soc import cheshire_pkg::*; #(
   axi_llc_pkg::events_t axi_llc_evts_all;
 
   // Selected LLC events
-  localparam int unsigned LlcNumEvts = 8;
+  localparam int unsigned LlcNumEvts = 10;
   localparam int unsigned LlcEvtCntWidth = 32;
 
   logic [LlcNumEvts-1:0] llc_evts;
@@ -448,7 +448,7 @@ module cheshire_soc import cheshire_pkg::*; #(
     logic [LlcEvtCntWidth-1:0] read;
   } llc_cnt_t;
 
-  llc_cnt_t llc_hit_cnt_cache, llc_miss_cnt_cache, llc_refill_cnt, llc_evict_cnt;
+  llc_cnt_t llc_hit_cnt_cache, llc_miss_cnt_cache, llc_refill_cnt, llc_evict_cnt, llc_access_cnt_cache;
 
   if (Cfg.LlcOutConnect) begin : gen_llc_atomics
 
@@ -547,15 +547,18 @@ module cheshire_soc import cheshire_pkg::*; #(
       .axi_llc_events_o    ( axi_llc_evts_all )
     );
 
-  // LLC events array comprises 24 17-bit `event_num_bytes_t` data structures and 4 1-bit event
-  // signals. The 24 structs track, for various events, (i) a level-sensitive signal corresponding
-  // to a handshake (1-bit `active` field), and (ii) the number of transferred bytes (16-bits
-  // `num_bytes` field) during the handshake. The 4 remaining 1-bit signals perform high-level
-  // tracking of evict, refill, write and read requests. We filter all this information and extract
-  // the `active` events for hit (w/r), miss (w/r), refill (w/r) and evict (w/r) to count how
-  // frequently an event happened, and collect this number in a register.
+  // LLC events array comprises 24 17-bit `event_num_bytes_t` data structures
+  // and 4 1-bit event signals. The 24 structs track, for various events, (i) a
+  // level-sensitive signal corresponding to a handshake (1-bit `active` field),
+  // and (ii) the number of transferred bytes (16-bits `num_bytes` field) during
+  // the handshake. The 4 remaining 1-bit signals perform high-level tracking of
+  // evict, refill, write and read requests. We filter all this information and
+  // extract the `active` events for accesses to the LLC (w/r), hits (w/r),
+  // misses (w/r), refills (w/r) and evictions (w/r) to count how frequently an
+  // event happened, and collect this number in a register.
 
-  assign llc_evts = { axi_llc_evts_all.evict_read.active,      axi_llc_evts_all.evict_write.active,
+  assign llc_evts = { axi_llc_evts_all.ar_desc_cache.active,   axi_llc_evts_all.aw_desc_cache.active,
+                      axi_llc_evts_all.evict_read.active,      axi_llc_evts_all.evict_write.active,
                       axi_llc_evts_all.refill_read.active,     axi_llc_evts_all.refill_write.active,
                       axi_llc_evts_all.miss_read_cache.active, axi_llc_evts_all.miss_write_cache.active,
                       axi_llc_evts_all.hit_read_cache.active,  axi_llc_evts_all.hit_write_cache.active
@@ -569,6 +572,8 @@ module cheshire_soc import cheshire_pkg::*; #(
   assign llc_refill_cnt.read      = llc_evt_cnts[RefillRead];
   assign llc_evict_cnt.write      = llc_evt_cnts[EvictWrite];
   assign llc_evict_cnt.read       = llc_evt_cnts[EvictRead];
+  assign llc_access_cnt_cache.write = llc_evt_cnts[WAccess];
+  assign llc_access_cnt_cache.read  = llc_evt_cnts[RAccess];
 
   for (genvar i=0; i < LlcNumEvts; i++) begin : gen_llc_evt_cntrs
     counter #(
@@ -1066,6 +1071,8 @@ module cheshire_soc import cheshire_pkg::*; #(
     llc_refill_cnt_read      : llc_refill_cnt.read,
     llc_evict_cnt_write      : llc_evict_cnt.write,
     llc_evict_cnt_read       : llc_evict_cnt.read,
+    llc_access_cnt_write_cache : llc_access_cnt_cache.write,
+    llc_access_cnt_read_cache  : llc_access_cnt_cache.read,
     vga_params    : '{
       red_width   : Cfg.VgaRedWidth,
       green_width : Cfg.VgaGreenWidth,

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -433,6 +433,23 @@ module cheshire_soc import cheshire_pkg::*; #(
   axi_slv_req_t axi_llc_cut_req;
   axi_slv_rsp_t axi_llc_cut_rsp;
 
+  // All LLC events
+  axi_llc_pkg::events_t axi_llc_evts_all;
+
+  // Selected LLC events
+  localparam int unsigned LlcNumEvts = 8;
+  localparam int unsigned LlcEvtCntWidth = 32;
+
+  logic [LlcNumEvts-1:0] llc_evts;
+  logic [LlcNumEvts-1:0][LlcEvtCntWidth-1:0] llc_evt_cnts;
+
+  typedef struct packed {
+    logic [LlcEvtCntWidth-1:0] write;
+    logic [LlcEvtCntWidth-1:0] read;
+  } llc_cnt_t;
+
+  llc_cnt_t llc_hit_cnt_cache, llc_miss_cnt_cache, llc_refill_cnt, llc_evict_cnt;
+
   if (Cfg.LlcOutConnect) begin : gen_llc_atomics
 
     axi_slv_req_t axi_llc_amo_req;
@@ -527,17 +544,60 @@ module cheshire_soc import cheshire_pkg::*; #(
       .cached_start_addr_i ( addr_t'(Cfg.LlcOutRegionStart) ),
       .cached_end_addr_i   ( addr_t'(Cfg.LlcOutRegionEnd)   ),
       .spm_start_addr_i    ( addr_t'(AmSpm) ),
-      .axi_llc_events_o    ( /* TODO: connect me to regs? */ )
+      .axi_llc_events_o    ( axi_llc_evts_all )
     );
+
+  // LLC events array comprises 24 17-bit `event_num_bytes_t` data structures and 4 1-bit event
+  // signals. The 24 structs track, for various events, (i) a level-sensitive signal corresponding
+  // to a handshake (1-bit `active` field), and (ii) the number of transferred bytes (16-bits
+  // `num_bytes` field) during the handshake. The 4 remaining 1-bit signals perform high-level
+  // tracking of evict, refill, write and read requests. We filter all this information and extract
+  // the `active` events for hit (w/r), miss (w/r), refill (w/r) and evict (w/r) to count how
+  // frequently an event happened, and collect this number in a register.
+
+  assign llc_evts = { axi_llc_evts_all.evict_read.active,      axi_llc_evts_all.evict_write.active,
+                      axi_llc_evts_all.refill_read.active,     axi_llc_evts_all.refill_write.active,
+                      axi_llc_evts_all.miss_read_cache.active, axi_llc_evts_all.miss_write_cache.active,
+                      axi_llc_evts_all.hit_read_cache.active,  axi_llc_evts_all.hit_write_cache.active
+                    };
+
+  assign llc_hit_cnt_cache.write  = llc_evt_cnts[HitWriteCache];
+  assign llc_hit_cnt_cache.read   = llc_evt_cnts[HitReadCache];
+  assign llc_miss_cnt_cache.write = llc_evt_cnts[MissWriteCache];
+  assign llc_miss_cnt_cache.read  = llc_evt_cnts[MissReadCache];
+  assign llc_refill_cnt.write     = llc_evt_cnts[RefillWrite];
+  assign llc_refill_cnt.read      = llc_evt_cnts[RefillRead];
+  assign llc_evict_cnt.write      = llc_evt_cnts[EvictWrite];
+  assign llc_evict_cnt.read       = llc_evt_cnts[EvictRead];
+
+  for (genvar i=0; i < LlcNumEvts; i++) begin : gen_llc_evt_cntrs
+    counter #(
+      .WIDTH ( LlcEvtCntWidth )
+    ) i_llc_evt_cnt (
+      .clk_i,
+      .rst_ni,
+      .clear_i   ( 1'b0 ),
+      .en_i      ( llc_evts[i] ),
+      .load_i    ( '0 ),
+      .down_i    ( 1'b0 ),
+      .d_i       ( '0 ),
+      .q_o       ( llc_evt_cnts[i] ),
+      .overflow_o( /* NOT CONNECTED */ )
+    );
+  end
 
   end else if (Cfg.LlcOutConnect) begin : gen_llc_bypass
 
-    assign axi_llc_mst_req_o  = axi_llc_cut_req;
-    assign axi_llc_cut_rsp    = axi_llc_mst_rsp_i;
+    assign axi_llc_mst_req_o = axi_llc_cut_req;
+    assign axi_llc_cut_rsp = axi_llc_mst_rsp_i;
+    assign axi_llc_evts_all = '0;
+    assign llc_evt_cnts = '0;
 
   end else begin : gen_llc_stubout
 
-    assign axi_llc_mst_req_o  = '0;
+    assign axi_llc_mst_req_o = '0;
+    assign axi_llc_evts_all = '0;
+    assign llc_evt_cnts = '0;
 
   end
 
@@ -998,6 +1058,14 @@ module cheshire_soc import cheshire_pkg::*; #(
       bus_err     : Cfg.BusErr
     },
     llc_size      : get_llc_size(Cfg),
+    llc_hit_cnt_write_cache  : llc_hit_cnt_cache.write,
+    llc_hit_cnt_read_cache   : llc_hit_cnt_cache.read,
+    llc_miss_cnt_write_cache : llc_miss_cnt_cache.write,
+    llc_miss_cnt_read_cache  : llc_miss_cnt_cache.read,
+    llc_refill_cnt_write     : llc_refill_cnt.write,
+    llc_refill_cnt_read      : llc_refill_cnt.read,
+    llc_evict_cnt_write      : llc_evict_cnt.write,
+    llc_evict_cnt_read       : llc_evict_cnt.read,
     vga_params    : '{
       red_width   : Cfg.VgaRedWidth,
       green_width : Cfg.VgaGreenWidth,

--- a/hw/regs/cheshire_reg_pkg.sv
+++ b/hw/regs/cheshire_reg_pkg.sv
@@ -7,7 +7,7 @@
 package cheshire_reg_pkg;
 
   // Address widths within the block
-  parameter int BlockAw = 7;
+  parameter int BlockAw = 8;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -108,6 +108,14 @@ package cheshire_reg_pkg;
   } cheshire_hw2reg_llc_evict_cnt_read_reg_t;
 
   typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_access_cnt_write_cache_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_access_cnt_read_cache_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic [7:0]  d;
     } red_width;
@@ -121,55 +129,59 @@ package cheshire_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    cheshire_hw2reg_boot_mode_reg_t boot_mode; // [422:421]
-    cheshire_hw2reg_rtc_freq_reg_t rtc_freq; // [420:389]
-    cheshire_hw2reg_platform_rom_reg_t platform_rom; // [388:357]
-    cheshire_hw2reg_num_int_harts_reg_t num_int_harts; // [356:325]
-    cheshire_hw2reg_hw_features_reg_t hw_features; // [324:312]
-    cheshire_hw2reg_llc_size_reg_t llc_size; // [311:280]
-    cheshire_hw2reg_llc_hit_cnt_write_cache_reg_t llc_hit_cnt_write_cache; // [279:248]
-    cheshire_hw2reg_llc_hit_cnt_read_cache_reg_t llc_hit_cnt_read_cache; // [247:216]
-    cheshire_hw2reg_llc_miss_cnt_write_cache_reg_t llc_miss_cnt_write_cache; // [215:184]
-    cheshire_hw2reg_llc_miss_cnt_read_cache_reg_t llc_miss_cnt_read_cache; // [183:152]
-    cheshire_hw2reg_llc_refill_cnt_write_reg_t llc_refill_cnt_write; // [151:120]
-    cheshire_hw2reg_llc_refill_cnt_read_reg_t llc_refill_cnt_read; // [119:88]
-    cheshire_hw2reg_llc_evict_cnt_write_reg_t llc_evict_cnt_write; // [87:56]
-    cheshire_hw2reg_llc_evict_cnt_read_reg_t llc_evict_cnt_read; // [55:24]
+    cheshire_hw2reg_boot_mode_reg_t boot_mode; // [486:485]
+    cheshire_hw2reg_rtc_freq_reg_t rtc_freq; // [484:453]
+    cheshire_hw2reg_platform_rom_reg_t platform_rom; // [452:421]
+    cheshire_hw2reg_num_int_harts_reg_t num_int_harts; // [420:389]
+    cheshire_hw2reg_hw_features_reg_t hw_features; // [388:376]
+    cheshire_hw2reg_llc_size_reg_t llc_size; // [375:344]
+    cheshire_hw2reg_llc_hit_cnt_write_cache_reg_t llc_hit_cnt_write_cache; // [343:312]
+    cheshire_hw2reg_llc_hit_cnt_read_cache_reg_t llc_hit_cnt_read_cache; // [311:280]
+    cheshire_hw2reg_llc_miss_cnt_write_cache_reg_t llc_miss_cnt_write_cache; // [279:248]
+    cheshire_hw2reg_llc_miss_cnt_read_cache_reg_t llc_miss_cnt_read_cache; // [247:216]
+    cheshire_hw2reg_llc_refill_cnt_write_reg_t llc_refill_cnt_write; // [215:184]
+    cheshire_hw2reg_llc_refill_cnt_read_reg_t llc_refill_cnt_read; // [183:152]
+    cheshire_hw2reg_llc_evict_cnt_write_reg_t llc_evict_cnt_write; // [151:120]
+    cheshire_hw2reg_llc_evict_cnt_read_reg_t llc_evict_cnt_read; // [119:88]
+    cheshire_hw2reg_llc_access_cnt_write_cache_reg_t llc_access_cnt_write_cache; // [87:56]
+    cheshire_hw2reg_llc_access_cnt_read_cache_reg_t llc_access_cnt_read_cache; // [55:24]
     cheshire_hw2reg_vga_params_reg_t vga_params; // [23:0]
   } cheshire_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_0_OFFSET = 7'h 0;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_1_OFFSET = 7'h 4;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_2_OFFSET = 7'h 8;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_3_OFFSET = 7'h c;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_4_OFFSET = 7'h 10;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_5_OFFSET = 7'h 14;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_6_OFFSET = 7'h 18;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_7_OFFSET = 7'h 1c;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_8_OFFSET = 7'h 20;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_9_OFFSET = 7'h 24;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_10_OFFSET = 7'h 28;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_11_OFFSET = 7'h 2c;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_12_OFFSET = 7'h 30;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_13_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_14_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_15_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] CHESHIRE_BOOT_MODE_OFFSET = 7'h 40;
-  parameter logic [BlockAw-1:0] CHESHIRE_RTC_FREQ_OFFSET = 7'h 44;
-  parameter logic [BlockAw-1:0] CHESHIRE_PLATFORM_ROM_OFFSET = 7'h 48;
-  parameter logic [BlockAw-1:0] CHESHIRE_NUM_INT_HARTS_OFFSET = 7'h 4c;
-  parameter logic [BlockAw-1:0] CHESHIRE_HW_FEATURES_OFFSET = 7'h 50;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_SIZE_OFFSET = 7'h 54;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_HIT_CNT_WRITE_CACHE_OFFSET = 7'h 58;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_HIT_CNT_READ_CACHE_OFFSET = 7'h 5c;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_MISS_CNT_WRITE_CACHE_OFFSET = 7'h 60;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_MISS_CNT_READ_CACHE_OFFSET = 7'h 64;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_REFILL_CNT_WRITE_OFFSET = 7'h 68;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_REFILL_CNT_READ_OFFSET = 7'h 6c;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_EVICT_CNT_WRITE_OFFSET = 7'h 70;
-  parameter logic [BlockAw-1:0] CHESHIRE_LLC_EVICT_CNT_READ_OFFSET = 7'h 74;
-  parameter logic [BlockAw-1:0] CHESHIRE_VGA_PARAMS_OFFSET = 7'h 78;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_0_OFFSET = 8'h 0;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_1_OFFSET = 8'h 4;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_2_OFFSET = 8'h 8;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_3_OFFSET = 8'h c;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_4_OFFSET = 8'h 10;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_5_OFFSET = 8'h 14;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_6_OFFSET = 8'h 18;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_7_OFFSET = 8'h 1c;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_8_OFFSET = 8'h 20;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_9_OFFSET = 8'h 24;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_10_OFFSET = 8'h 28;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_11_OFFSET = 8'h 2c;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_12_OFFSET = 8'h 30;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_13_OFFSET = 8'h 34;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_14_OFFSET = 8'h 38;
+  parameter logic [BlockAw-1:0] CHESHIRE_SCRATCH_15_OFFSET = 8'h 3c;
+  parameter logic [BlockAw-1:0] CHESHIRE_BOOT_MODE_OFFSET = 8'h 40;
+  parameter logic [BlockAw-1:0] CHESHIRE_RTC_FREQ_OFFSET = 8'h 44;
+  parameter logic [BlockAw-1:0] CHESHIRE_PLATFORM_ROM_OFFSET = 8'h 48;
+  parameter logic [BlockAw-1:0] CHESHIRE_NUM_INT_HARTS_OFFSET = 8'h 4c;
+  parameter logic [BlockAw-1:0] CHESHIRE_HW_FEATURES_OFFSET = 8'h 50;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_SIZE_OFFSET = 8'h 54;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_HIT_CNT_WRITE_CACHE_OFFSET = 8'h 58;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_HIT_CNT_READ_CACHE_OFFSET = 8'h 5c;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_MISS_CNT_WRITE_CACHE_OFFSET = 8'h 60;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_MISS_CNT_READ_CACHE_OFFSET = 8'h 64;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_REFILL_CNT_WRITE_OFFSET = 8'h 68;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_REFILL_CNT_READ_OFFSET = 8'h 6c;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_EVICT_CNT_WRITE_OFFSET = 8'h 70;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_EVICT_CNT_READ_OFFSET = 8'h 74;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_ACCESS_CNT_WRITE_CACHE_OFFSET = 8'h 78;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_ACCESS_CNT_READ_CACHE_OFFSET = 8'h 7c;
+  parameter logic [BlockAw-1:0] CHESHIRE_VGA_PARAMS_OFFSET = 8'h 80;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] CHESHIRE_BOOT_MODE_RESVAL = 2'h 0;
@@ -186,6 +198,8 @@ package cheshire_reg_pkg;
   parameter logic [31:0] CHESHIRE_LLC_REFILL_CNT_READ_RESVAL = 32'h 0;
   parameter logic [31:0] CHESHIRE_LLC_EVICT_CNT_WRITE_RESVAL = 32'h 0;
   parameter logic [31:0] CHESHIRE_LLC_EVICT_CNT_READ_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_ACCESS_CNT_WRITE_CACHE_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_ACCESS_CNT_READ_CACHE_RESVAL = 32'h 0;
   parameter logic [23:0] CHESHIRE_VGA_PARAMS_RESVAL = 24'h 0;
 
   // Register index
@@ -220,11 +234,13 @@ package cheshire_reg_pkg;
     CHESHIRE_LLC_REFILL_CNT_READ,
     CHESHIRE_LLC_EVICT_CNT_WRITE,
     CHESHIRE_LLC_EVICT_CNT_READ,
+    CHESHIRE_LLC_ACCESS_CNT_WRITE_CACHE,
+    CHESHIRE_LLC_ACCESS_CNT_READ_CACHE,
     CHESHIRE_VGA_PARAMS
   } cheshire_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CHESHIRE_PERMIT [31] = '{
+  parameter logic [3:0] CHESHIRE_PERMIT [33] = '{
     4'b 1111, // index[ 0] CHESHIRE_SCRATCH_0
     4'b 1111, // index[ 1] CHESHIRE_SCRATCH_1
     4'b 1111, // index[ 2] CHESHIRE_SCRATCH_2
@@ -255,7 +271,9 @@ package cheshire_reg_pkg;
     4'b 1111, // index[27] CHESHIRE_LLC_REFILL_CNT_READ
     4'b 1111, // index[28] CHESHIRE_LLC_EVICT_CNT_WRITE
     4'b 1111, // index[29] CHESHIRE_LLC_EVICT_CNT_READ
-    4'b 0111  // index[30] CHESHIRE_VGA_PARAMS
+    4'b 1111, // index[30] CHESHIRE_LLC_ACCESS_CNT_WRITE_CACHE
+    4'b 1111, // index[31] CHESHIRE_LLC_ACCESS_CNT_READ_CACHE
+    4'b 0111  // index[32] CHESHIRE_VGA_PARAMS
   };
 
 endpackage

--- a/hw/regs/cheshire_reg_pkg.sv
+++ b/hw/regs/cheshire_reg_pkg.sv
@@ -76,6 +76,38 @@ package cheshire_reg_pkg;
   } cheshire_hw2reg_llc_size_reg_t;
 
   typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_hit_cnt_write_cache_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_hit_cnt_read_cache_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_miss_cnt_write_cache_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_miss_cnt_read_cache_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_refill_cnt_write_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_refill_cnt_read_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_evict_cnt_write_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } cheshire_hw2reg_llc_evict_cnt_read_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic [7:0]  d;
     } red_width;
@@ -89,12 +121,20 @@ package cheshire_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    cheshire_hw2reg_boot_mode_reg_t boot_mode; // [166:165]
-    cheshire_hw2reg_rtc_freq_reg_t rtc_freq; // [164:133]
-    cheshire_hw2reg_platform_rom_reg_t platform_rom; // [132:101]
-    cheshire_hw2reg_num_int_harts_reg_t num_int_harts; // [100:69]
-    cheshire_hw2reg_hw_features_reg_t hw_features; // [68:56]
-    cheshire_hw2reg_llc_size_reg_t llc_size; // [55:24]
+    cheshire_hw2reg_boot_mode_reg_t boot_mode; // [422:421]
+    cheshire_hw2reg_rtc_freq_reg_t rtc_freq; // [420:389]
+    cheshire_hw2reg_platform_rom_reg_t platform_rom; // [388:357]
+    cheshire_hw2reg_num_int_harts_reg_t num_int_harts; // [356:325]
+    cheshire_hw2reg_hw_features_reg_t hw_features; // [324:312]
+    cheshire_hw2reg_llc_size_reg_t llc_size; // [311:280]
+    cheshire_hw2reg_llc_hit_cnt_write_cache_reg_t llc_hit_cnt_write_cache; // [279:248]
+    cheshire_hw2reg_llc_hit_cnt_read_cache_reg_t llc_hit_cnt_read_cache; // [247:216]
+    cheshire_hw2reg_llc_miss_cnt_write_cache_reg_t llc_miss_cnt_write_cache; // [215:184]
+    cheshire_hw2reg_llc_miss_cnt_read_cache_reg_t llc_miss_cnt_read_cache; // [183:152]
+    cheshire_hw2reg_llc_refill_cnt_write_reg_t llc_refill_cnt_write; // [151:120]
+    cheshire_hw2reg_llc_refill_cnt_read_reg_t llc_refill_cnt_read; // [119:88]
+    cheshire_hw2reg_llc_evict_cnt_write_reg_t llc_evict_cnt_write; // [87:56]
+    cheshire_hw2reg_llc_evict_cnt_read_reg_t llc_evict_cnt_read; // [55:24]
     cheshire_hw2reg_vga_params_reg_t vga_params; // [23:0]
   } cheshire_hw2reg_t;
 
@@ -121,7 +161,15 @@ package cheshire_reg_pkg;
   parameter logic [BlockAw-1:0] CHESHIRE_NUM_INT_HARTS_OFFSET = 7'h 4c;
   parameter logic [BlockAw-1:0] CHESHIRE_HW_FEATURES_OFFSET = 7'h 50;
   parameter logic [BlockAw-1:0] CHESHIRE_LLC_SIZE_OFFSET = 7'h 54;
-  parameter logic [BlockAw-1:0] CHESHIRE_VGA_PARAMS_OFFSET = 7'h 58;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_HIT_CNT_WRITE_CACHE_OFFSET = 7'h 58;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_HIT_CNT_READ_CACHE_OFFSET = 7'h 5c;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_MISS_CNT_WRITE_CACHE_OFFSET = 7'h 60;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_MISS_CNT_READ_CACHE_OFFSET = 7'h 64;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_REFILL_CNT_WRITE_OFFSET = 7'h 68;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_REFILL_CNT_READ_OFFSET = 7'h 6c;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_EVICT_CNT_WRITE_OFFSET = 7'h 70;
+  parameter logic [BlockAw-1:0] CHESHIRE_LLC_EVICT_CNT_READ_OFFSET = 7'h 74;
+  parameter logic [BlockAw-1:0] CHESHIRE_VGA_PARAMS_OFFSET = 7'h 78;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] CHESHIRE_BOOT_MODE_RESVAL = 2'h 0;
@@ -130,6 +178,14 @@ package cheshire_reg_pkg;
   parameter logic [31:0] CHESHIRE_NUM_INT_HARTS_RESVAL = 32'h 0;
   parameter logic [12:0] CHESHIRE_HW_FEATURES_RESVAL = 13'h 0;
   parameter logic [31:0] CHESHIRE_LLC_SIZE_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_HIT_CNT_WRITE_CACHE_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_HIT_CNT_READ_CACHE_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_MISS_CNT_WRITE_CACHE_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_MISS_CNT_READ_CACHE_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_REFILL_CNT_WRITE_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_REFILL_CNT_READ_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_EVICT_CNT_WRITE_RESVAL = 32'h 0;
+  parameter logic [31:0] CHESHIRE_LLC_EVICT_CNT_READ_RESVAL = 32'h 0;
   parameter logic [23:0] CHESHIRE_VGA_PARAMS_RESVAL = 24'h 0;
 
   // Register index
@@ -156,11 +212,19 @@ package cheshire_reg_pkg;
     CHESHIRE_NUM_INT_HARTS,
     CHESHIRE_HW_FEATURES,
     CHESHIRE_LLC_SIZE,
+    CHESHIRE_LLC_HIT_CNT_WRITE_CACHE,
+    CHESHIRE_LLC_HIT_CNT_READ_CACHE,
+    CHESHIRE_LLC_MISS_CNT_WRITE_CACHE,
+    CHESHIRE_LLC_MISS_CNT_READ_CACHE,
+    CHESHIRE_LLC_REFILL_CNT_WRITE,
+    CHESHIRE_LLC_REFILL_CNT_READ,
+    CHESHIRE_LLC_EVICT_CNT_WRITE,
+    CHESHIRE_LLC_EVICT_CNT_READ,
     CHESHIRE_VGA_PARAMS
   } cheshire_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CHESHIRE_PERMIT [23] = '{
+  parameter logic [3:0] CHESHIRE_PERMIT [31] = '{
     4'b 1111, // index[ 0] CHESHIRE_SCRATCH_0
     4'b 1111, // index[ 1] CHESHIRE_SCRATCH_1
     4'b 1111, // index[ 2] CHESHIRE_SCRATCH_2
@@ -183,7 +247,15 @@ package cheshire_reg_pkg;
     4'b 1111, // index[19] CHESHIRE_NUM_INT_HARTS
     4'b 0011, // index[20] CHESHIRE_HW_FEATURES
     4'b 1111, // index[21] CHESHIRE_LLC_SIZE
-    4'b 0111  // index[22] CHESHIRE_VGA_PARAMS
+    4'b 1111, // index[22] CHESHIRE_LLC_HIT_CNT_WRITE_CACHE
+    4'b 1111, // index[23] CHESHIRE_LLC_HIT_CNT_READ_CACHE
+    4'b 1111, // index[24] CHESHIRE_LLC_MISS_CNT_WRITE_CACHE
+    4'b 1111, // index[25] CHESHIRE_LLC_MISS_CNT_READ_CACHE
+    4'b 1111, // index[26] CHESHIRE_LLC_REFILL_CNT_WRITE
+    4'b 1111, // index[27] CHESHIRE_LLC_REFILL_CNT_READ
+    4'b 1111, // index[28] CHESHIRE_LLC_EVICT_CNT_WRITE
+    4'b 1111, // index[29] CHESHIRE_LLC_EVICT_CNT_READ
+    4'b 0111  // index[30] CHESHIRE_VGA_PARAMS
   };
 
 endpackage

--- a/hw/regs/cheshire_reg_top.sv
+++ b/hw/regs/cheshire_reg_top.sv
@@ -151,6 +151,22 @@ module cheshire_reg_top #(
   logic hw_features_bus_err_re;
   logic [31:0] llc_size_qs;
   logic llc_size_re;
+  logic [31:0] llc_hit_cnt_write_cache_qs;
+  logic llc_hit_cnt_write_cache_re;
+  logic [31:0] llc_hit_cnt_read_cache_qs;
+  logic llc_hit_cnt_read_cache_re;
+  logic [31:0] llc_miss_cnt_write_cache_qs;
+  logic llc_miss_cnt_write_cache_re;
+  logic [31:0] llc_miss_cnt_read_cache_qs;
+  logic llc_miss_cnt_read_cache_re;
+  logic [31:0] llc_refill_cnt_write_qs;
+  logic llc_refill_cnt_write_re;
+  logic [31:0] llc_refill_cnt_read_qs;
+  logic llc_refill_cnt_read_re;
+  logic [31:0] llc_evict_cnt_write_qs;
+  logic llc_evict_cnt_write_re;
+  logic [31:0] llc_evict_cnt_read_qs;
+  logic llc_evict_cnt_read_re;
   logic [7:0] vga_params_red_width_qs;
   logic vga_params_red_width_re;
   logic [7:0] vga_params_green_width_qs;
@@ -870,6 +886,134 @@ module cheshire_reg_top #(
   );
 
 
+  // R[llc_hit_cnt_write_cache]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_llc_hit_cnt_write_cache (
+    .re     (llc_hit_cnt_write_cache_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.llc_hit_cnt_write_cache.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (llc_hit_cnt_write_cache_qs)
+  );
+
+
+  // R[llc_hit_cnt_read_cache]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_llc_hit_cnt_read_cache (
+    .re     (llc_hit_cnt_read_cache_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.llc_hit_cnt_read_cache.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (llc_hit_cnt_read_cache_qs)
+  );
+
+
+  // R[llc_miss_cnt_write_cache]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_llc_miss_cnt_write_cache (
+    .re     (llc_miss_cnt_write_cache_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.llc_miss_cnt_write_cache.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (llc_miss_cnt_write_cache_qs)
+  );
+
+
+  // R[llc_miss_cnt_read_cache]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_llc_miss_cnt_read_cache (
+    .re     (llc_miss_cnt_read_cache_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.llc_miss_cnt_read_cache.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (llc_miss_cnt_read_cache_qs)
+  );
+
+
+  // R[llc_refill_cnt_write]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_llc_refill_cnt_write (
+    .re     (llc_refill_cnt_write_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.llc_refill_cnt_write.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (llc_refill_cnt_write_qs)
+  );
+
+
+  // R[llc_refill_cnt_read]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_llc_refill_cnt_read (
+    .re     (llc_refill_cnt_read_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.llc_refill_cnt_read.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (llc_refill_cnt_read_qs)
+  );
+
+
+  // R[llc_evict_cnt_write]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_llc_evict_cnt_write (
+    .re     (llc_evict_cnt_write_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.llc_evict_cnt_write.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (llc_evict_cnt_write_qs)
+  );
+
+
+  // R[llc_evict_cnt_read]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_llc_evict_cnt_read (
+    .re     (llc_evict_cnt_read_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.llc_evict_cnt_read.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (llc_evict_cnt_read_qs)
+  );
+
+
   // R[vga_params]: V(True)
 
   //   F[red_width]: 7:0
@@ -919,7 +1063,7 @@ module cheshire_reg_top #(
 
 
 
-  logic [22:0] addr_hit;
+  logic [30:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CHESHIRE_SCRATCH_0_OFFSET);
@@ -944,7 +1088,15 @@ module cheshire_reg_top #(
     addr_hit[19] = (reg_addr == CHESHIRE_NUM_INT_HARTS_OFFSET);
     addr_hit[20] = (reg_addr == CHESHIRE_HW_FEATURES_OFFSET);
     addr_hit[21] = (reg_addr == CHESHIRE_LLC_SIZE_OFFSET);
-    addr_hit[22] = (reg_addr == CHESHIRE_VGA_PARAMS_OFFSET);
+    addr_hit[22] = (reg_addr == CHESHIRE_LLC_HIT_CNT_WRITE_CACHE_OFFSET);
+    addr_hit[23] = (reg_addr == CHESHIRE_LLC_HIT_CNT_READ_CACHE_OFFSET);
+    addr_hit[24] = (reg_addr == CHESHIRE_LLC_MISS_CNT_WRITE_CACHE_OFFSET);
+    addr_hit[25] = (reg_addr == CHESHIRE_LLC_MISS_CNT_READ_CACHE_OFFSET);
+    addr_hit[26] = (reg_addr == CHESHIRE_LLC_REFILL_CNT_WRITE_OFFSET);
+    addr_hit[27] = (reg_addr == CHESHIRE_LLC_REFILL_CNT_READ_OFFSET);
+    addr_hit[28] = (reg_addr == CHESHIRE_LLC_EVICT_CNT_WRITE_OFFSET);
+    addr_hit[29] = (reg_addr == CHESHIRE_LLC_EVICT_CNT_READ_OFFSET);
+    addr_hit[30] = (reg_addr == CHESHIRE_VGA_PARAMS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -974,7 +1126,15 @@ module cheshire_reg_top #(
                (addr_hit[19] & (|(CHESHIRE_PERMIT[19] & ~reg_be))) |
                (addr_hit[20] & (|(CHESHIRE_PERMIT[20] & ~reg_be))) |
                (addr_hit[21] & (|(CHESHIRE_PERMIT[21] & ~reg_be))) |
-               (addr_hit[22] & (|(CHESHIRE_PERMIT[22] & ~reg_be)))));
+               (addr_hit[22] & (|(CHESHIRE_PERMIT[22] & ~reg_be))) |
+               (addr_hit[23] & (|(CHESHIRE_PERMIT[23] & ~reg_be))) |
+               (addr_hit[24] & (|(CHESHIRE_PERMIT[24] & ~reg_be))) |
+               (addr_hit[25] & (|(CHESHIRE_PERMIT[25] & ~reg_be))) |
+               (addr_hit[26] & (|(CHESHIRE_PERMIT[26] & ~reg_be))) |
+               (addr_hit[27] & (|(CHESHIRE_PERMIT[27] & ~reg_be))) |
+               (addr_hit[28] & (|(CHESHIRE_PERMIT[28] & ~reg_be))) |
+               (addr_hit[29] & (|(CHESHIRE_PERMIT[29] & ~reg_be))) |
+               (addr_hit[30] & (|(CHESHIRE_PERMIT[30] & ~reg_be)))));
   end
 
   assign scratch_0_we = addr_hit[0] & reg_we & !reg_error;
@@ -1061,11 +1221,27 @@ module cheshire_reg_top #(
 
   assign llc_size_re = addr_hit[21] & reg_re & !reg_error;
 
-  assign vga_params_red_width_re = addr_hit[22] & reg_re & !reg_error;
+  assign llc_hit_cnt_write_cache_re = addr_hit[22] & reg_re & !reg_error;
 
-  assign vga_params_green_width_re = addr_hit[22] & reg_re & !reg_error;
+  assign llc_hit_cnt_read_cache_re = addr_hit[23] & reg_re & !reg_error;
 
-  assign vga_params_blue_width_re = addr_hit[22] & reg_re & !reg_error;
+  assign llc_miss_cnt_write_cache_re = addr_hit[24] & reg_re & !reg_error;
+
+  assign llc_miss_cnt_read_cache_re = addr_hit[25] & reg_re & !reg_error;
+
+  assign llc_refill_cnt_write_re = addr_hit[26] & reg_re & !reg_error;
+
+  assign llc_refill_cnt_read_re = addr_hit[27] & reg_re & !reg_error;
+
+  assign llc_evict_cnt_write_re = addr_hit[28] & reg_re & !reg_error;
+
+  assign llc_evict_cnt_read_re = addr_hit[29] & reg_re & !reg_error;
+
+  assign vga_params_red_width_re = addr_hit[30] & reg_re & !reg_error;
+
+  assign vga_params_green_width_re = addr_hit[30] & reg_re & !reg_error;
+
+  assign vga_params_blue_width_re = addr_hit[30] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -1172,6 +1348,38 @@ module cheshire_reg_top #(
       end
 
       addr_hit[22]: begin
+        reg_rdata_next[31:0] = llc_hit_cnt_write_cache_qs;
+      end
+
+      addr_hit[23]: begin
+        reg_rdata_next[31:0] = llc_hit_cnt_read_cache_qs;
+      end
+
+      addr_hit[24]: begin
+        reg_rdata_next[31:0] = llc_miss_cnt_write_cache_qs;
+      end
+
+      addr_hit[25]: begin
+        reg_rdata_next[31:0] = llc_miss_cnt_read_cache_qs;
+      end
+
+      addr_hit[26]: begin
+        reg_rdata_next[31:0] = llc_refill_cnt_write_qs;
+      end
+
+      addr_hit[27]: begin
+        reg_rdata_next[31:0] = llc_refill_cnt_read_qs;
+      end
+
+      addr_hit[28]: begin
+        reg_rdata_next[31:0] = llc_evict_cnt_write_qs;
+      end
+
+      addr_hit[29]: begin
+        reg_rdata_next[31:0] = llc_evict_cnt_read_qs;
+      end
+
+      addr_hit[30]: begin
         reg_rdata_next[7:0] = vga_params_red_width_qs;
         reg_rdata_next[15:8] = vga_params_green_width_qs;
         reg_rdata_next[23:16] = vga_params_blue_width_qs;

--- a/hw/regs/cheshire_regs.hjson
+++ b/hw/regs/cheshire_regs.hjson
@@ -205,6 +205,28 @@
       ]
     }
 
+    { name:     "llc_access_cnt_write_cache"
+      desc:     "Performance counter for LLC accesses on the write path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_access_cnt_write_cache", desc: "Performance counter for LLC accesses on the write path" }
+      ]
+    }
+
+    { name:     "llc_access_cnt_read_cache"
+      desc:     "Performance counter for LLC accesses on the read path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_access_cnt_read_cache", desc: "Performance counter for LLC accesses on the read path" }
+      ]
+    }
+
     { name:     "vga_params"
       desc:     "VGA hardware parameters"
       swaccess: "ro"

--- a/hw/regs/cheshire_regs.hjson
+++ b/hw/regs/cheshire_regs.hjson
@@ -18,14 +18,14 @@
 
     { multireg:
       { name:     "scratch"
-        desc:     "Registers for use by software"
-        swaccess: "rw"
-        hwaccess: "none"
-        count:    "16"
-        cname:    "scratch"
-        fields: [
-          { bits: "31:0", resval: "0", name: "scratch", desc: "Registers for use by software" }
-        ]
+	desc:     "Registers for use by software"
+	swaccess: "rw"
+	hwaccess: "none"
+	count:    "16"
+	cname:    "scratch"
+	fields: [
+	  { bits: "31:0", resval: "0", name: "scratch", desc: "Registers for use by software" }
+	]
       }
     }
 
@@ -36,16 +36,16 @@
       hwqe:     "true"
       hwext:    "true"
       fields: [
-        { bits: "1:0"
-          name: "boot_mode"
-          desc: "Method to load boot code (connected to input pins)"
-          enum: [
-            { value: "0", name: "passive",       desc: "Wait for external preload and launch"  }
-            { value: "1", name: "spi_sdcard",    desc: "Boot from SD Card in SPI mode"         }
-            { value: "2", name: "spi_s25fs512s", desc: "Boot from S25FS512S SPI NOR flash"     }
-            { value: "3", name: "i2c_24xx1025",  desc: "Boot from 24xx1025 I2C EEPROM"         }
-          ]
-        }
+	{ bits: "1:0"
+	  name: "boot_mode"
+	  desc: "Method to load boot code (connected to input pins)"
+	  enum: [
+	    { value: "0", name: "passive",       desc: "Wait for external preload and launch"  }
+	    { value: "1", name: "spi_sdcard",    desc: "Boot from SD Card in SPI mode"         }
+	    { value: "2", name: "spi_s25fs512s", desc: "Boot from S25FS512S SPI NOR flash"     }
+	    { value: "3", name: "i2c_24xx1025",  desc: "Boot from 24xx1025 I2C EEPROM"         }
+	  ]
+	}
       ]
     }
 
@@ -56,7 +56,7 @@
       hwqe:     "true"
       hwext:    "true"
       fields: [
-        { bits: "31:0", name: "ref_freq", desc: "Frequency (Hz) configured for RTC" }
+	{ bits: "31:0", name: "ref_freq", desc: "Frequency (Hz) configured for RTC" }
       ]
     }
 
@@ -67,7 +67,7 @@
       hwqe:     "true"
       hwext:    "true"
       fields: [
-        { bits: "31:0", name: "platform_rom", desc: "Address of platform ROM" }
+	{ bits: "31:0", name: "platform_rom", desc: "Address of platform ROM" }
       ]
     }
 
@@ -78,7 +78,7 @@
       hwqe:     "true"
       hwext:    "true"
       fields: [
-        { bits: "31:0", name: "num_harts", desc: "Number of internal harts" }
+	{ bits: "31:0", name: "num_harts", desc: "Number of internal harts" }
       ]
     }
 
@@ -89,19 +89,19 @@
       hwqe:     "true"
       hwext:    "true"
       fields: [
-        { bits: "0",  name: "bootrom",      desc: "Whether boot ROM is available"     }
-        { bits: "1",  name: "llc",          desc: "Whether LLC is available"          }
-        { bits: "2",  name: "uart",         desc: "Whether UART is available"         }
-        { bits: "3",  name: "spi_host",     desc: "Whether SPI host is available"     }
-        { bits: "4",  name: "i2c",          desc: "Whether I2C is available"          }
-        { bits: "5",  name: "gpio",         desc: "Whether GPIO is available"         }
-        { bits: "6",  name: "dma",          desc: "Whether DMA is available"          }
-        { bits: "7",  name: "serial_link",  desc: "Whether serial link is available"  }
-        { bits: "8",  name: "vga",          desc: "Whether VGA is available"          }
-        { bits: "9",  name: "axirt",        desc: "Whether AXI RT is available"       }
-        { bits: "10", name: "clic",         desc: "Whether CLIC is available"         }
-        { bits: "11", name: "irq_router",   desc: "Whether IRQ router is available"   }
-        { bits: "12", name: "bus_err",      desc: "Whether UNBENT is available"       }
+	{ bits: "0",  name: "bootrom",      desc: "Whether boot ROM is available"     }
+	{ bits: "1",  name: "llc",          desc: "Whether LLC is available"          }
+	{ bits: "2",  name: "uart",         desc: "Whether UART is available"         }
+	{ bits: "3",  name: "spi_host",     desc: "Whether SPI host is available"     }
+	{ bits: "4",  name: "i2c",          desc: "Whether I2C is available"          }
+	{ bits: "5",  name: "gpio",         desc: "Whether GPIO is available"         }
+	{ bits: "6",  name: "dma",          desc: "Whether DMA is available"          }
+	{ bits: "7",  name: "serial_link",  desc: "Whether serial link is available"  }
+	{ bits: "8",  name: "vga",          desc: "Whether VGA is available"          }
+	{ bits: "9",  name: "axirt",        desc: "Whether AXI RT is available"       }
+	{ bits: "10", name: "clic",         desc: "Whether CLIC is available"         }
+	{ bits: "11", name: "irq_router",   desc: "Whether IRQ router is available"   }
+	{ bits: "12", name: "bus_err",      desc: "Whether UNBENT is available"       }
       ]
     }
 
@@ -112,8 +112,96 @@
       hwqe:     "true"
       hwext:    "true"
       fields: [
-        { bits: "31:0", name: "llc_size", desc: "Total size of LLC in bytes" }
+	{ bits: "31:0", name: "llc_size", desc: "Total size of LLC in bytes" }
 
+      ]
+    }
+
+    { name:     "llc_hit_cnt_write_cache"
+      desc:     "Performance counter for LLC hits on the cache write path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_hit_cnt_write", desc: "Performance counter for LLC hits on the cache write path" }
+      ]
+    }
+
+    { name:     "llc_hit_cnt_read_cache"
+      desc:     "Performance counter for LLC hits on the cache read path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_hit_cnt_read", desc: "Performance counter for LLC hits on the cache read path" }
+      ]
+    }
+
+    { name:     "llc_miss_cnt_write_cache"
+      desc:     "Performance counter for LLC misses on the cache write path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_miss_cnt_write", desc: "Performance counter for LLC misses on the cache write path" }
+      ]
+    }
+
+    { name:     "llc_miss_cnt_read_cache"
+      desc:     "Performance counter for LLC misses on the cache read path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_miss_cnt_read", desc: "Performance counter for LLC misses on the cache read path" }
+      ]
+    }
+
+    { name:     "llc_refill_cnt_write"
+      desc:     "Performance counter for LLC refills on the write path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_refill_cnt_write", desc: "Performance counter for LLC refills on the write path" }
+      ]
+    }
+
+    { name:     "llc_refill_cnt_read"
+      desc:     "Performance counter for LLC refills on the read path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_refill_cnt_read", desc: "Performance counter for LLC refills on the read path" }
+      ]
+    }
+
+    { name:     "llc_evict_cnt_write"
+      desc:     "Performance counter for LLC evictions on the write path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_evict_cnt_write", desc: "Performance counter for LLC evictions on the write path" }
+      ]
+    }
+
+    { name:     "llc_evict_cnt_read"
+      desc:     "Performance counter for LLC evictions on the read path"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwqe:     "true"
+      hwext:    "true"
+      fields: [
+	{ bits: "31:0", name: "llc_evict_cnt_read", desc: "Performance counter for LLC evictions on the read path" }
       ]
     }
 
@@ -124,9 +212,9 @@
       hwqe:     "true"
       hwext:    "true"
       fields: [
-        { bits: "7:0",    name: "red_width",    desc: "Red channel width"   }
-        { bits: "15:8",   name: "green_width",  desc: "Green channel width" }
-        { bits: "23:16",  name: "blue_width",   desc: "Blue channel width"  }
+	{ bits: "7:0",    name: "red_width",    desc: "Red channel width"   }
+	{ bits: "15:8",   name: "green_width",  desc: "Green channel width" }
+	{ bits: "23:16",  name: "blue_width",   desc: "Blue channel width"  }
 
       ]
     }

--- a/sw/include/regs/cheshire.h
+++ b/sw/include/regs/cheshire.h
@@ -108,8 +108,32 @@ extern "C" {
 // Total size of LLC in bytes
 #define CHESHIRE_LLC_SIZE_REG_OFFSET 0x54
 
+// Performance counter for LLC hits on the cache write path
+#define CHESHIRE_LLC_HIT_CNT_WRITE_CACHE_REG_OFFSET 0x58
+
+// Performance counter for LLC hits on the cache read path
+#define CHESHIRE_LLC_HIT_CNT_READ_CACHE_REG_OFFSET 0x5c
+
+// Performance counter for LLC misses on the cache write path
+#define CHESHIRE_LLC_MISS_CNT_WRITE_CACHE_REG_OFFSET 0x60
+
+// Performance counter for LLC misses on the cache read path
+#define CHESHIRE_LLC_MISS_CNT_READ_CACHE_REG_OFFSET 0x64
+
+// Performance counter for LLC refills on the write path
+#define CHESHIRE_LLC_REFILL_CNT_WRITE_REG_OFFSET 0x68
+
+// Performance counter for LLC refills on the read path
+#define CHESHIRE_LLC_REFILL_CNT_READ_REG_OFFSET 0x6c
+
+// Performance counter for LLC evictions on the write path
+#define CHESHIRE_LLC_EVICT_CNT_WRITE_REG_OFFSET 0x70
+
+// Performance counter for LLC evictions on the read path
+#define CHESHIRE_LLC_EVICT_CNT_READ_REG_OFFSET 0x74
+
 // VGA hardware parameters
-#define CHESHIRE_VGA_PARAMS_REG_OFFSET 0x58
+#define CHESHIRE_VGA_PARAMS_REG_OFFSET 0x78
 #define CHESHIRE_VGA_PARAMS_RED_WIDTH_MASK 0xff
 #define CHESHIRE_VGA_PARAMS_RED_WIDTH_OFFSET 0
 #define CHESHIRE_VGA_PARAMS_RED_WIDTH_FIELD \

--- a/sw/include/regs/cheshire.h
+++ b/sw/include/regs/cheshire.h
@@ -132,8 +132,14 @@ extern "C" {
 // Performance counter for LLC evictions on the read path
 #define CHESHIRE_LLC_EVICT_CNT_READ_REG_OFFSET 0x74
 
+// Performance counter for LLC accesses on the write path
+#define CHESHIRE_LLC_ACCESS_CNT_WRITE_CACHE_REG_OFFSET 0x78
+
+// Performance counter for LLC accesses on the read path
+#define CHESHIRE_LLC_ACCESS_CNT_READ_CACHE_REG_OFFSET 0x7c
+
 // VGA hardware parameters
-#define CHESHIRE_VGA_PARAMS_REG_OFFSET 0x78
+#define CHESHIRE_VGA_PARAMS_REG_OFFSET 0x80
 #define CHESHIRE_VGA_PARAMS_RED_WIDTH_MASK 0xff
 #define CHESHIRE_VGA_PARAMS_RED_WIDTH_OFFSET 0
 #define CHESHIRE_VGA_PARAMS_RED_WIDTH_FIELD \


### PR DESCRIPTION
* Count hit/miss/refill/evict/access events
* Store in status regs