### PR TITLE
target/sim: Correctly handle empty UART lines

### DIFF
--- a/target/sim/src/vip_cheshire_soc.sv
+++ b/target/sim/src/vip_cheshire_soc.sv
@@ -445,8 +445,12 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
         uart_boot_byte  = bite;
         uart_boot_ena = 0;
       end else if (bite == "\n") begin
-        $display("[UART] %s", {>>8{uart_read_buf}});
-        uart_read_buf.delete();
+        if (uart_read_buf.size() > 0) begin
+          $display("[UART] %s", {>>8{uart_read_buf}});
+          uart_read_buf.delete();
+        end else begin
+          $display("[UART]");
+        end
       end else if (bite == UartDebugEoc) begin
         uart_boot_eoc = 1;
       end else begin


### PR DESCRIPTION
Currently, printing empty lines (back-to-back `\n`s) causes Questasim to crash while attempting to stream the empty `uart_read_buf`. Fix this by checking if `uart_read_buf` is empty.