### PR TITLE
make: Formalize phonies and document tool path vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,13 @@ all:
 
 include cheshire.mk
 
-# Inside the repo, forward (prefixed) all, nonfree, and clean targets
-all:
-	@$(MAKE) chs-all
+# Locally, make Cheshire phonies available without `chs_` prefix
+define chs_phony_fwd_rule
+$(patsubst chs-%,%,$(1)): $(1)
+endef
 
-%-all:
-	@$(MAKE) chs-$*-all
+$(foreach phony,$(CHS_PHONY),$(eval $(call chs_phony_fwd_rule,$(phony))))
 
-nonfree-%:
-	@$(MAKE) chs-nonfree-$*
-
-clean-%:
-	@$(MAKE) chs-clean-$*
+help:
+	@echo "Possible phonies (may not all be implemented):"
+	@$(foreach phony,$(sort $(CHS_PHONY)),echo '- $(patsubst chs-%,%,$(phony))';)

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -12,7 +12,6 @@ BENDER ?= bender
 CXX_PATH := $(shell which $(CXX))
 
 VLOG_ARGS ?= -suppress 2583 -suppress 13314 -timescale 1ns/1ps
-VSIM      ?= vsim
 
 # Define used paths (prefixed to avoid name conflicts)
 CHS_ROOT      ?= $(shell $(BENDER) path cheshire)

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -48,6 +48,7 @@ ifeq ($(shell test -f $(BENDER_ROOT)/.chs_deps && echo 1),)
 endif
 
 # Running this target will reset dependencies (without updating the checked-in Bender.lock)
+CHS_PHONY += chs-clean-deps
 chs-clean-deps:
 	rm -rf .bender
 	cd $(CHS_ROOT) && rm -rf target/sim/models target/sim/dramsys
@@ -60,6 +61,7 @@ chs-clean-deps:
 CHS_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/cheshire-nonfree.git
 CHS_NONFREE_COMMIT ?= f731b17
 
+CHS_PHONY += chs-nonfree-init
 chs-nonfree-init:
 	git clone $(CHS_NONFREE_REMOTE) $(CHS_ROOT)/nonfree
 	cd $(CHS_ROOT)/nonfree && git checkout $(CHS_NONFREE_COMMIT)
@@ -179,8 +181,6 @@ include $(CHS_ROOT)/target/xilinx/xilinx.mk
 # Phonies (KEEP AT END OF FILE) #
 #################################
 
-.PHONY: chs-all chs-nonfree-init chs-clean-deps chs-sw-all chs-hw-all chs-bootrom-all chs-sim-all chs-dramsys-all chs-xilinx-all
-
 CHS_ALL += $(CHS_SW_ALL) $(CHS_HW_ALL) $(CHS_SIM_ALL)
 
 chs-all:         $(CHS_ALL)
@@ -190,3 +190,7 @@ chs-bootrom-all: $(CHS_BOOTROM_ALL)
 chs-sim-all:     $(CHS_SIM_ALL)
 chs-dramsys-all: $(CHS_DRAMSYS_ALL)
 chs-xilinx-all:  $(CHS_XILINX_ALL)
+
+CHS_PHONY += chs-all chs-sw-all chs-hw-all chs-bootrom-all chs-sim-all chs-dramsys-all chs-xilinx-all
+
+.PHONY: $(CHS_PHONY)

--- a/docs/gs.md
+++ b/docs/gs.md
@@ -34,6 +34,15 @@ cargo install bender
 
 Depending on your desired target, additional dependencies may be needed.
 
+## Tool Paths
+
+Our build system assumes sane default paths for tools. However, you may need to repoint the following environment variables to specify the correct install locations on your system:
+
+- `BENDER`: Path to Bender binary.
+- `CXX_PATH`: Path to host C++ compiler within full toolchain installation (used for SystemVerilog DPI).
+- `CHS_SW_GCC_BINROOT`: Path of RV64 GCC compiler within full toolchain installation.
+- `CHS_SW_DTC`: Linux device tree compiler.
+
 ## Building Cheshire
 
 To build different parts of Cheshire, run `make` followed by these targets:

--- a/docs/tg/xilinx.md
+++ b/docs/tg/xilinx.md
@@ -11,6 +11,12 @@ We currently provide working setups for:
 
 We are working on support for more boards in the future.
 
+We assume that the `VIVADO` environment variable points to the main binary of your Vivado installation. Before proceeding, you can set this variable for your current shell as follows:
+
+```
+export VIVADO="/path/to/your/vivado"
+```
+
 ## Implementation
 
 Generate the bitstream `target/xilinx/out/cheshire.<myboard>.bit` for your desired board by running:

--- a/target/xilinx/xilinx.mk
+++ b/target/xilinx/xilinx.mk
@@ -54,7 +54,7 @@ $$(CHS_XILINX_DIR)/out/%.$(1).bit: \
 	cd $$| && $$(VIVADO) -mode batch -log ../$$*.$(1).log -jou ../$$*.$(1).jou -source $$< \
 		-tclargs $(1) $$* $$(CHS_XILINX_IPS_$(1):%=$$(CHS_XILINX_DIR)/build/$(1).%/out.xci)
 
-.PHONY: chs-xilinx-$(1)
+CHS_PHONY += chs-xilinx-$(1)
 chs-xilinx-$(1): $$(CHS_XILINX_DIR)/out/cheshire.$(1).bit
 endef
 
@@ -72,7 +72,9 @@ CHS_XILINX_ALL = $(foreach board,$(CHS_XILINX_BOARDS),$$(CHS_XILINX_DIR)/out/che
 CHS_XILINX_HWS_URL ?= localhost:3121
 
 # We build the dependency file $(2) only if it does not exist; it must not be up to date.
+# We add PHONYs for each board as despite the implicit rule, these should be explicit.
 define chs_xilinx_util_rule
+CHS_PHONY += $(foreach board,$(CHS_XILINX_BOARDS),chs-xilinx-$(1)-$(board))
 chs-xilinx-$(1)-%: $$(CHS_XILINX_DIR)/scripts/util/$(1).tcl | $$(CHS_XILINX_DIR)/build/%.$(1)/
 	[ -e $(subst %,$$*,$(2)) ] || $$(MAKE) $(subst %,$$*,$(2))
 	@rm -f $$(CHS_XILINX_DIR)/build/$$(*)*.$(1).log $$(CHS_XILINX_DIR)/build/$$(*)*.$(1).jou
@@ -81,11 +83,9 @@ chs-xilinx-$(1)-%: $$(CHS_XILINX_DIR)/scripts/util/$(1).tcl | $$(CHS_XILINX_DIR)
 endef
 
 # Program bitstream onto board
-.PHONY: chs-xilinx-program-%
 $(eval $(call chs_xilinx_util_rule,program,$(CHS_XILINX_DIR)/out/cheshire.%.bit))
 
 # Flash onboard memory with the file `CHS_XILINX_FLASH_IMG` (only selected boards).
 # `%` is substituted with the board name. The default is the Linux disk image for that board.
 CHS_XILINX_FLASH_IMG ?= $(CHS_SW_DIR)/boot/linux.%.gpt.bin
-.PHONY: chs-xilinx-flash-%
 $(eval $(call chs_xilinx_util_rule,flash,$(CHS_XILINX_FLASH_IMG)))

--- a/target/xilinx/xilinx.mk
+++ b/target/xilinx/xilinx.mk
@@ -75,7 +75,8 @@ CHS_XILINX_HWS_URL ?= localhost:3121
 # We add PHONYs for each board as despite the implicit rule, these should be explicit.
 define chs_xilinx_util_rule
 CHS_PHONY += $(foreach board,$(CHS_XILINX_BOARDS),chs-xilinx-$(1)-$(board))
-chs-xilinx-$(1)-%: $$(CHS_XILINX_DIR)/scripts/util/$(1).tcl | $$(CHS_XILINX_DIR)/build/%.$(1)/
+$(foreach board,$(CHS_XILINX_BOARDS),chs-xilinx-$(1)-$(board)): chs-xilinx-$(1)-%: \
+		$$(CHS_XILINX_DIR)/scripts/util/$(1).tcl | $$(CHS_XILINX_DIR)/build/%.$(1)/
 	[ -e $(subst %,$$*,$(2)) ] || $$(MAKE) $(subst %,$$*,$(2))
 	@rm -f $$(CHS_XILINX_DIR)/build/$$(*)*.$(1).log $$(CHS_XILINX_DIR)/build/$$(*)*.$(1).jou
 	cd $$| && $$(VIVADO) -mode batch -log ../$$(*).$(1).log -jou ../$$(*).$(1).jou -source $$< \


### PR DESCRIPTION
* Explicitly collect phonies in `CHS_PHONY`:
  * cleaner approach
  * fixes tricky issues with recursive make invocation
* Provides a list of defined phonies through `make help`
* Documents tool paths used (Fixes #130).