### PR TITLE
Correctly initialize stack pointer in memisl linker script

### DIFF
--- a/sw/link/memisl.ld
+++ b/sw/link/memisl.ld
@@ -9,6 +9,8 @@
 INCLUDE common.ldh
 
 SECTIONS {
+  __stack_pointer$  = ORIGIN(memisl) + LENGTH(memisl);
+
   .text : {
     *(.text._start)
     *(.text)


### PR DESCRIPTION
The stack pointer was not being initialized in the linker script for the Memory island. This caused the usage of a corrupted stack pointer and unexpected behaviors when the stack was used.