### PR TITLE
decrease bootrom SPI frequency

### DIFF
--- a/hw/bootrom/cheshire_bootrom.c
+++ b/hw/bootrom/cheshire_bootrom.c
@@ -37,7 +37,7 @@ int boot_passive(uint64_t core_freq) {
 int boot_spi_sdcard(uint64_t core_freq, uint64_t rtc_freq) {
     // Initialize device handle
     spi_sdcard_t device = {
-        .spi_freq = 24 * 1000 * 1000, // 24MHz (maximum is 25MHz)
+        .spi_freq = 1 * 1000 * 1000, // 24MHz (maximum is 25MHz)
         .csid = 0,
         .csid_dummy = SPI_HOST_PARAM_NUM_C_S - 1 // Last physical CS is designated dummy
     };


### PR DESCRIPTION
As we use the PMOD SD Card Adapter to connect the SD card to the FPGA in the VCU118, and considering that there is a buffer in between, the pull-up resistors mounted on the adapter are too high, which causes a very low rise time. This results in the FPGA not capturing data correctly from the SD card. One solution is to decrease the SPI frequency until we achieve a reasonable rise time.