### PR TITLE
Ara integration in Cheshire (2)

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -15,7 +15,7 @@ packages:
     - apb
     - register_interface
   ara:
-    revision: 3dad93de70c6bb20c4c0b20780d96d4243f94136
+    revision: 9ea9e56b784b6f8994710fe3030d900d44966a4e
     version: null
     source:
       Git: https://github.com/pulp-platform/ara.git
@@ -103,7 +103,7 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cva6:
-    revision: 99ae53bde1a94b90c1d9bbbe7fe272a9336200a6
+    revision: 5614fc9ceeae6db3851e8c721de868355db9476b
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -15,7 +15,7 @@ packages:
     - apb
     - register_interface
   ara:
-    revision: 9ea9e56b784b6f8994710fe3030d900d44966a4e
+    revision: 19985464b2d8801f21900c1f9d6d7dd356f92b8b
     version: null
     source:
       Git: https://github.com/pulp-platform/ara.git
@@ -103,7 +103,7 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cva6:
-    revision: 5614fc9ceeae6db3851e8c721de868355db9476b
+    revision: 5086bff7a039f02a2d9604bca7b1b3e9d961713e
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -22,8 +22,8 @@ dependencies:
   clint:                    { git: "https://github.com/pulp-platform/clint.git",                  version: 0.2.0  }
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",           version: 1.33.0 }
   common_verification:      { git: "https://github.com/pulp-platform/common_verification.git",    version: 0.2.0  }
-  cva6:                     { git: "https://github.com/pulp-platform/cva6.git",                   rev: pulp-v1    }
-  ara:                      { git: "https://github.com/pulp-platform/ara.git",                    rev: mp/cva6-pulpv1/rebase }
+  cva6:                     { git: "https://github.com/pulp-platform/cva6.git",                   rev: mp/pulp-v1-araOS }
+  ara:                      { git: "https://github.com/pulp-platform/ara.git",                    rev: mp/pulp-v1-os-fpga }
   iDMA:                     { git: "https://github.com/pulp-platform/iDMA.git",                   version: 0.5.1  }
   irq_router:               { git: "https://github.com/pulp-platform/irq_router.git",             version: 0.0.1-beta.1 }
   opentitan_peripherals:    { git: "https://github.com/pulp-platform/opentitan_peripherals.git",  version: 0.4.0  }

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -58,7 +58,7 @@ chs-clean-deps:
 ######################
 
 CHS_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/cheshire-nonfree.git
-CHS_NONFREE_COMMIT ?= dc0a4e4c08d185829e7e7934fb458ed429cd10ec
+CHS_NONFREE_COMMIT ?= d514a884aeef03ae3d9fcb7166e169417d00f991
 
 CHS_PHONY += chs-nonfree-init
 chs-nonfree-init:

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -557,8 +557,8 @@ module cheshire_soc import cheshire_pkg::*; #(
   // TODO: Implement X interface support
 
   // Accelerator ports
-  acc_pkg::accelerator_req_t  acc_req;
-  acc_pkg::accelerator_resp_t acc_resp;
+  acc_pkg::cva6_to_acc_t acc_req;
+  acc_pkg::acc_to_cva6_t acc_resp;
 
   // CVA6-Ara memory consistency
   logic                     acc_cons_en;
@@ -567,13 +567,13 @@ module cheshire_soc import cheshire_pkg::*; #(
   logic                     inval_ready;
 
   // Pack invalidation interface into acc interface
-  acc_pkg::accelerator_resp_t acc_resp_pack;
+  acc_pkg::acc_to_cva6_t acc_resp_pack;
   always_comb begin : pack_inval
-    acc_resp_pack             = acc_resp;
-    acc_resp_pack.inval_valid = inval_valid;
-    acc_resp_pack.inval_addr  = inval_addr;
-    inval_ready               = acc_req.inval_ready;
-    acc_cons_en               = acc_req.acc_cons_en;
+    acc_resp_pack                      = acc_resp;
+    acc_resp_pack.acc_resp.inval_valid = inval_valid;
+    acc_resp_pack.acc_resp.inval_addr  = inval_addr;
+    inval_ready                        = acc_req.acc_req.inval_ready;
+    acc_cons_en                        = acc_req.acc_req.acc_cons_en;
   end
 
   `CHESHIRE_TYPEDEF_AXI_CT(axi_cva6, addr_t, cva6_id_t, axi_data_t, axi_strb_t, axi_user_t)
@@ -626,8 +626,8 @@ module cheshire_soc import cheshire_pkg::*; #(
       .axi_w_chan_t   ( axi_cva6_w_chan_t  ),
       .b_chan_t       ( axi_cva6_b_chan_t  ),
       .r_chan_t       ( axi_cva6_r_chan_t  ),
-      .cvxif_req_t    ( acc_pkg::accelerator_req_t  ),
-      .cvxif_resp_t   ( acc_pkg::accelerator_resp_t ),
+      .cvxif_req_t    ( acc_pkg::cva6_to_acc_t ),
+      .cvxif_resp_t   ( acc_pkg::acc_to_cva6_t ),
       .noc_req_t      ( axi_cva6_req_t ),
       .noc_resp_t     ( axi_cva6_rsp_t )
     ) i_core_cva6 (

--- a/target/xilinx/src/cheshire_top_xilinx.sv
+++ b/target/xilinx/src/cheshire_top_xilinx.sv
@@ -98,6 +98,11 @@ module cheshire_top_xilinx import cheshire_pkg::*; (
   `else
     ret.Usb = 0;
   `endif
+  `ifdef ARA
+    ret.Ara = 1;
+    ret.AraVLEN = `ifdef VLEN `VLEN `else 0 `endif;
+    ret.AraNrLanes = `ifdef NR_LANES `NR_LANES `else 0 `endif;
+  `endif
     return ret;
   endfunction
 


### PR DESCRIPTION
## This is the second PR for Ara's FPGA and OS support. See https://github.com/pulp-platform/cheshire/pull/112 for the bare-metal one.

- Add support for back-referencing FPGA flow (i.e., by driving the FPGA implementation from Ara's directory).
- Adapt Ara-CVA6 interface to support virtual memory.
- Bump Ara and CVA6.
- Update the CI to test RVV Linux, Cheshire + Ara on VCU128, and its Linux boot.

Before merging, Ara and CVA6 should be referenced with TAGs laying on the `main` branch.

PR moved to https://github.com/pulp-platform/cheshire/pull/231, to integrate CVA6 version `pulp-v2`.