### PR TITLE
hw: Fix uncached SPM accessibility

### DIFF
--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -501,9 +501,9 @@ module cheshire_soc import cheshire_pkg::*; #(
     // This is necessary for routing in the LLC-internal interconnect.
     always_comb begin
       axi_llc_remap_req = axi_llc_cut_req;
-      if (axi_llc_cut_req.aw.addr & ~AmSpmRegionMask == AmSpmBaseUncached & ~AmSpmRegionMask)
+      if ((axi_llc_cut_req.aw.addr & ~AmSpmRegionMask) == (AmSpmBaseUncached & ~AmSpmRegionMask))
         axi_llc_remap_req.aw.addr  = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.aw.addr);
-      if (axi_llc_cut_req.ar.addr & ~AmSpmRegionMask == AmSpmBaseUncached & ~AmSpmRegionMask)
+      if ((axi_llc_cut_req.ar.addr & ~AmSpmRegionMask) == (AmSpmBaseUncached & ~AmSpmRegionMask))
         axi_llc_remap_req.ar.addr = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.ar.addr);
       axi_llc_cut_rsp = axi_llc_remap_rsp;
     end


### PR DESCRIPTION
The equality operator `==` has precedence over the bitwise and operator `&` .