### PR TITLE
hw: Update iDMA to `v0.6.3`

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -52,6 +52,13 @@ packages:
     - axi
     - common_cells
     - register_interface
+  axi_stream:
+    revision: 54891ff40455ca94a37641b9da4604647878cc07
+    version: 0.1.1
+    source:
+      Git: https://github.com/pulp-platform/axi_stream.git
+    dependencies:
+    - common_cells
   axi_vga:
     revision: 3718b9930f94a9eaad8ee50b4bccc71df0403084
     version: 0.1.3
@@ -124,14 +131,16 @@ packages:
     dependencies:
     - common_cells
   idma:
-    revision: ca1b28816a3706be0bf9ce01378246d5346384f0
-    version: 0.5.1
+    revision: c12caf59bb482fe44b27361f6924ad346b2d22fe
+    version: 0.6.3
     source:
       Git: https://github.com/pulp-platform/iDMA.git
     dependencies:
     - axi
+    - axi_stream
     - common_cells
     - common_verification
+    - obi
     - register_interface
   irq_router:
     revision: d1d31350b24f3965b3a51e1bc96c71eb34e94db3
@@ -142,6 +151,14 @@ packages:
     - axi
     - common_cells
     - register_interface
+  obi:
+    revision: 5321106817e177d6c16ecc4daa922b96b1bc946b
+    version: 0.1.5
+    source:
+      Git: https://github.com/pulp-platform/obi.git
+    dependencies:
+    - common_cells
+    - common_verification
   opentitan_peripherals:
     revision: cd3153de2783abd3d03d0595e6c4b32413c62f14
     version: 0.4.0

--- a/Bender.yml
+++ b/Bender.yml
@@ -23,7 +23,7 @@ dependencies:
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",           version: 1.33.0 }
   common_verification:      { git: "https://github.com/pulp-platform/common_verification.git",    version: 0.2.0  }
   cva6:                     { git: "https://github.com/pulp-platform/cva6.git",                   rev: pulp-v1.0.0 }
-  iDMA:                     { git: "https://github.com/pulp-platform/iDMA.git",                   version: 0.5.1  }
+  iDMA:                     { git: "https://github.com/pulp-platform/iDMA.git",                   version: 0.6.3  }
   irq_router:               { git: "https://github.com/pulp-platform/irq_router.git",             version: 0.0.1-beta.1 }
   opentitan_peripherals:    { git: "https://github.com/pulp-platform/opentitan_peripherals.git",  version: 0.4.0  }
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git",     version: 0.4.4  }
@@ -41,6 +41,7 @@ sources:
   - hw/bootrom/cheshire_bootrom.sv
   - hw/regs/cheshire_reg_pkg.sv
   - hw/regs/cheshire_reg_top.sv
+  - hw/cheshire_idma_wrap.sv
   - hw/cheshire_pkg.sv
   - hw/cheshire_soc.sv
 

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -109,6 +109,10 @@ $(CHS_SLINK_DIR)/.generated: $(CHS_ROOT)/hw/serial_link.hjson
 	cp $< $(dir $@)/src/regs/serial_link_single_channel.hjson
 	flock -x $@ $(MAKE) -C $(CHS_SLINK_DIR) update-regs BENDER="$(BENDER)" && touch $@
 
+# iDMA
+include $(IDMA_ROOT)/idma.mk
+
+CHS_HW_ALL += $(IDMA_FULL_RTL)
 CHS_HW_ALL += $(CHS_ROOT)/hw/regs/cheshire_reg_pkg.sv $(CHS_ROOT)/hw/regs/cheshire_reg_top.sv
 CHS_HW_ALL += $(CLINTROOT)/.generated
 CHS_HW_ALL += $(OTPROOT)/.generated

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -13,6 +13,9 @@ CXX_PATH := $(shell which $(CXX))
 
 VLOG_ARGS ?= -suppress 2583 -suppress 13314 -timescale 1ns/1ps
 
+# Common Bender flags for Cheshire RTL
+CHS_BENDER_RTL_FLAGS ?= -t rtl -t cva6 -t cv64a6_imafdcsclic_sv39
+
 # Define used paths (prefixed to avoid name conflicts)
 CHS_ROOT      ?= $(shell $(BENDER) path cheshire)
 CHS_REG_DIR   := $(shell $(BENDER) path register_interface)
@@ -143,7 +146,7 @@ CHS_BOOTROM_ALL += $(CHS_ROOT)/hw/bootrom/cheshire_bootrom.sv $(CHS_ROOT)/hw/boo
 ##############
 
 $(CHS_ROOT)/target/sim/vsim/compile.cheshire_soc.tcl: $(CHS_ROOT)/Bender.yml
-	$(BENDER) script vsim -t sim -t cv64a6_imafdcsclic_sv39 -t test -t cva6 -t rtl --vlog-arg="$(VLOG_ARGS)" > $@
+	$(BENDER) script vsim -t sim -t test $(CHS_BENDER_RTL_FLAGS) --vlog-arg="$(VLOG_ARGS)" > $@
 	echo 'vlog "$(realpath $(CHS_ROOT))/target/sim/src/elfloader.cpp" -ccflags "-std=c++11" -cpppath "$(CXX_PATH)"' >> $@
 
 .PRECIOUS: $(CHS_ROOT)/target/sim/models

--- a/hw/cheshire_idma_wrap.sv
+++ b/hw/cheshire_idma_wrap.sv
@@ -1,0 +1,343 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Thomas Benz    <tbenz@iis.ee.ethz.ch>
+// Author: Andreas Kuster <kustera@ethz.ch>
+// Author: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+// Author: Chaoqun Liang  <chaoqun.liang@unibo.it>
+
+// Description: DMA core wrapper for the CVA6 integration
+
+`include "axi/assign.svh"
+`include "axi/typedef.svh"
+`include "idma/typedef.svh"
+`include "register_interface/typedef.svh"
+
+module cheshire_idma_wrap #(
+  parameter int unsigned AxiAddrWidth     = 0,
+  parameter int unsigned AxiDataWidth     = 0,
+  parameter int unsigned AxiIdWidth       = 0,
+  parameter int unsigned AxiUserWidth     = 0,
+  parameter int unsigned AxiSlvIdWidth    = 0,
+  parameter int unsigned NumAxInFlight    = 0,
+  parameter int unsigned MemSysDepth      = 0,
+  parameter int unsigned JobFifoDepth     = 0,
+  parameter bit          RAWCouplingAvail = 0,
+  parameter bit          IsTwoD           = 0,
+  parameter type         axi_mst_req_t    = logic,
+  parameter type         axi_mst_rsp_t    = logic,
+  parameter type         axi_slv_req_t    = logic,
+  parameter type         axi_slv_rsp_t    = logic
+) (
+  input  logic          clk_i,
+  input  logic          rst_ni,
+  input  logic          testmode_i,
+  output axi_mst_req_t  axi_mst_req_o,
+  input  axi_mst_rsp_t  axi_mst_rsp_i,
+  input  axi_slv_req_t  axi_slv_req_i,
+  output axi_slv_rsp_t  axi_slv_rsp_o
+);
+
+  localparam int unsigned IdCounterWidth  = 32;
+  localparam int unsigned NumDim          = 2;
+  localparam int unsigned RepWidth        = 32;
+  localparam int unsigned TfLenWidth      = 32;
+
+  typedef logic [AxiDataWidth-1:0]     data_t;
+  typedef logic [AxiDataWidth/8-1:0]   strb_t;
+  typedef logic [AxiAddrWidth-1:0]     addr_t;
+  typedef logic [AxiIdWidth-1:0]       id_t;
+  typedef logic [AxiSlvIdWidth-1:0]    slv_id_t;
+  typedef logic [AxiUserWidth-1:0]     user_t;
+  typedef logic [TfLenWidth-1:0]       tf_len_t;
+  typedef logic [IdCounterWidth-1:0]   tf_id_t;
+  typedef logic [RepWidth-1:0]         reps_t;
+  typedef logic [RepWidth-1:0]         strides_t;
+
+  // AXI4+ATOP typedefs
+  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, addr_t, id_t, user_t)
+  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, addr_t, id_t, user_t)
+
+  // iDMA request / response types
+  `IDMA_TYPEDEF_FULL_REQ_T(idma_req_t, id_t, addr_t, tf_len_t)
+  `IDMA_TYPEDEF_FULL_RSP_T(idma_rsp_t, addr_t)
+  `IDMA_TYPEDEF_FULL_ND_REQ_T(idma_nd_req_t, idma_req_t, tf_len_t, tf_len_t)
+
+  `REG_BUS_TYPEDEF_ALL(dma_regs, addr_t, data_t, strb_t)
+
+  typedef struct packed {
+    axi_ar_chan_t ar_chan;
+  } axi_read_meta_channel_t;
+
+  typedef struct packed {
+    axi_read_meta_channel_t axi;
+  } read_meta_channel_t;
+
+  typedef struct packed {
+    axi_aw_chan_t aw_chan;
+  } axi_write_meta_channel_t;
+
+  typedef struct packed {
+    axi_write_meta_channel_t axi;
+  } write_meta_channel_t;
+
+  dma_regs_req_t dma_reg_req;
+  dma_regs_rsp_t dma_reg_rsp;
+
+  // 1D FE signals
+  idma_req_t    burst_req_d;
+  logic         be_valid_d;
+  logic         be_ready_d;
+
+  // ND FE signals
+  idma_nd_req_t idma_nd_req_d;
+  logic         idma_nd_req_valid_d;
+  logic         idma_nd_req_ready_d;
+
+  // ND ME signals
+  idma_nd_req_t idma_nd_req;
+  logic         idma_nd_req_valid;
+  logic         idma_nd_req_ready;
+  logic         idma_nd_rsp_valid;
+  logic         idma_nd_rsp_ready;
+
+  // BE signals
+  idma_req_t    burst_req;
+  logic         be_valid;
+  logic         be_ready;
+  idma_rsp_t    idma_rsp;
+  logic         idma_rsp_valid;
+  logic         idma_rsp_ready;
+
+  // ID signals
+  logic              issue_id;
+  logic              retire_id;
+  logic [IdCounterWidth-1:0] done_id, next_id;
+
+  // Status signals
+  idma_pkg::idma_busy_t busy;
+  logic me_busy;
+
+  // Internal AXI channels
+  axi_mst_req_t axi_read_req, axi_write_req;
+  axi_mst_rsp_t axi_read_rsp, axi_write_rsp;
+
+  axi_to_reg #(
+    .ADDR_WIDTH ( AxiAddrWidth  ),
+    .DATA_WIDTH ( AxiDataWidth  ),
+    .ID_WIDTH   ( AxiSlvIdWidth ),
+    .USER_WIDTH ( AxiUserWidth  ),
+    .axi_req_t  ( axi_slv_req_t ),
+    .axi_rsp_t  ( axi_slv_rsp_t ),
+    .reg_req_t  ( dma_regs_req_t ),
+    .reg_rsp_t  ( dma_regs_rsp_t )
+  ) i_axi_translate (
+    .clk_i,
+    .rst_ni,
+    .testmode_i,
+    .axi_req_i  ( axi_slv_req_i ),
+    .axi_rsp_o  ( axi_slv_rsp_o ),
+    .reg_req_o  ( dma_reg_req ),
+    .reg_rsp_i  ( dma_reg_rsp )
+   );
+
+  if (!IsTwoD) begin : gen_1d
+
+    idma_reg64_1d #(
+      .NumRegs        ( 32'd1 ),
+      .NumStreams     ( 32'd1 ),
+      .IdCounterWidth ( IdCounterWidth ),
+      .reg_req_t      ( dma_regs_req_t ),
+      .reg_rsp_t      ( dma_regs_rsp_t ),
+      .dma_req_t      ( idma_req_t )
+    ) i_dma_frontend_1d (
+      .clk_i,
+      .rst_ni,
+      .dma_ctrl_req_i ( dma_reg_req ),
+      .dma_ctrl_rsp_o ( dma_reg_rsp ),
+      .dma_req_o      ( burst_req_d ),
+      .req_valid_o    ( be_valid_d  ),
+      .req_ready_i    ( be_ready_d  ),
+      .next_id_i      ( next_id ),
+      .stream_idx_o   ( ),
+      .done_id_i      ( done_id ),
+      .busy_i         ( idma_busy ),
+      .midend_busy_i  ( 1'b0 )
+    );
+
+    stream_fifo_optimal_wrap #(
+      .Depth      ( JobFifoDepth ),
+      .type_t     ( idma_req_t   ),
+      .PrintInfo  ( 0 )
+    ) i_stream_fifo_jobs_1d (
+      .clk_i,
+      .rst_ni,
+      .testmode_i,
+      .flush_i    ( 1'b0 ),
+      .usage_o    ( ),
+      .data_i     ( burst_req_d ),
+      .valid_i    ( be_valid_d  ),
+      .ready_o    ( be_ready_d  ),
+      .data_o     ( burst_req ),
+      .valid_o    ( be_valid  ),
+      .ready_i    ( be_ready  )
+    );
+
+    assign retire_id = idma_rsp_valid & idma_rsp_ready;
+    assign issue_id  = be_valid_d & be_ready_d;
+    assign idma_rsp_ready = 1'b1;
+
+    idma_transfer_id_gen #(
+      .IdWidth ( IdCounterWidth )
+    ) i_transfer_id_gen_1d (
+      .clk_i,
+      .rst_ni,
+      .issue_i      ( issue_id  ),
+      .retire_i     ( retire_id ),
+      .next_o       ( next_id   ),
+      .completed_o  ( done_id   )
+    );
+
+  end else begin : gen_2d
+    idma_reg64_2d #(
+      .NumRegs        ( 1 ),
+      .NumStreams     ( 1 ),
+      .IdCounterWidth ( IdCounterWidth ),
+      .reg_req_t      ( dma_regs_req_t ),
+      .reg_rsp_t      ( dma_regs_rsp_t ),
+      .dma_req_t      ( idma_nd_req_t  )
+    ) idma_frontend_2d (
+      .clk_i,
+      .rst_ni,
+      .dma_ctrl_req_i ( dma_reg_req   ),
+      .dma_ctrl_rsp_o ( dma_reg_rsp   ),
+      .dma_req_o      ( idma_nd_req_d ),
+      .req_valid_o    ( idma_nd_req_valid_d ),
+      .req_ready_i    ( idma_nd_req_ready_d ),
+      .next_id_i      ( next_id ),
+      .stream_idx_o   (         ),
+      .done_id_i      ( done_id ),
+      .busy_i         ( busy    ),
+      .midend_busy_i  ( me_busy )
+    );
+
+    stream_fifo_optimal_wrap #(
+      .Depth      ( JobFifoDepth  ),
+      .type_t     ( idma_nd_req_t ),
+      .PrintInfo  ( 0 )
+    ) i_stream_fifo_jobs_2d (
+      .clk_i,
+      .rst_ni,
+      .testmode_i,
+      .flush_i    ( 1'b0 ),
+      .usage_o    ( ),
+      .data_i     ( idma_nd_req_d       ),
+      .valid_i    ( idma_nd_req_valid_d ),
+      .ready_o    ( idma_nd_req_ready_d ),
+      .data_o     ( idma_nd_req       ),
+      .valid_o    ( idma_nd_req_valid ),
+      .ready_i    ( idma_nd_req_ready )
+    );
+
+    idma_nd_midend #(
+      .NumDim         ( NumDim ),
+      .addr_t         ( addr_t ),
+      .idma_req_t     ( idma_req_t ),
+      .idma_rsp_t     ( idma_rsp_t ),
+      .idma_nd_req_t  ( idma_nd_req_t ),
+      .RepWidths      ( RepWidth )
+    ) i_idma_midend (
+      .clk_i,
+      .rst_ni,
+      .nd_req_i           ( idma_nd_req       ),
+      .nd_req_valid_i     ( idma_nd_req_valid ),
+      .nd_req_ready_o     ( idma_nd_req_ready ),
+      .nd_rsp_o           ( ),
+      .nd_rsp_valid_o     ( idma_nd_rsp_valid ),
+      .nd_rsp_ready_i     ( idma_nd_rsp_ready ),
+      .burst_req_o        ( burst_req ),
+      .burst_req_valid_o  ( be_valid  ),
+      .burst_req_ready_i  ( be_ready  ),
+      .burst_rsp_i        ( idma_rsp       ),
+      .burst_rsp_valid_i  ( idma_rsp_valid ),
+      .burst_rsp_ready_o  ( idma_rsp_ready ),
+      .busy_o             ( me_busy )
+    );
+
+    assign retire_id = idma_nd_rsp_valid & idma_nd_rsp_ready;
+    assign issue_id  = idma_nd_req_valid_d & idma_nd_req_ready_d;
+    assign idma_nd_rsp_ready = 1'b1;
+
+    idma_transfer_id_gen #(
+      .IdWidth ( IdCounterWidth )
+    ) i_transfer_id_gen_2d (
+      .clk_i,
+      .rst_ni,
+      .issue_i      ( issue_id  ),
+      .retire_i     ( retire_id ),
+      .next_o       ( next_id   ),
+      .completed_o  ( done_id   )
+    );
+
+  end
+
+  idma_backend_rw_axi #(
+    .CombinedShifter      ( 1'b0 ),
+    .DataWidth            ( AxiDataWidth ),
+    .AddrWidth            ( AxiAddrWidth ),
+    .AxiIdWidth           ( AxiIdWidth   ),
+    .UserWidth            ( AxiUserWidth ),
+    .TFLenWidth           ( TfLenWidth ),
+    .MaskInvalidData      ( 1 ),
+    .BufferDepth          ( 3 ),
+    .RAWCouplingAvail     ( RAWCouplingAvail),
+    .HardwareLegalizer    ( 1 ),
+    .RejectZeroTransfers  ( 1 ),
+    .ErrorCap             ( idma_pkg::NO_ERROR_HANDLING ),
+    .PrintFifoInfo        ( 0 ),
+    .NumAxInFlight        ( NumAxInFlight ),
+    .MemSysDepth          ( MemSysDepth ),
+    .idma_req_t           ( idma_req_t  ),
+    .idma_rsp_t           ( idma_rsp_t  ),
+    .idma_eh_req_t        ( idma_pkg::idma_eh_req_t ),
+    .idma_busy_t          ( idma_pkg::idma_busy_t   ),
+    .axi_req_t            ( axi_mst_req_t ),
+    .axi_rsp_t            ( axi_mst_rsp_t ),
+    .write_meta_channel_t ( write_meta_channel_t ),
+    .read_meta_channel_t  ( read_meta_channel_t  )
+  ) i_idma_backend  (
+    .clk_i,
+    .rst_ni,
+    .testmode_i,
+    .idma_req_i       ( burst_req ),
+    .req_valid_i      ( be_valid  ),
+    .req_ready_o      ( be_ready  ),
+    .idma_rsp_o       ( idma_rsp       ),
+    .rsp_valid_o      ( idma_rsp_valid ),
+    .rsp_ready_i      ( idma_rsp_ready ),
+    .idma_eh_req_i    ( '0 ),
+    .eh_req_valid_i   ( '0 ),
+    .eh_req_ready_o   ( ),
+    .axi_read_req_o   ( axi_read_req ),
+    .axi_read_rsp_i   ( axi_read_rsp ),
+    .axi_write_req_o  ( axi_write_req ),
+    .axi_write_rsp_i  ( axi_write_rsp ),
+    .busy_o           ( busy )
+  );
+
+  axi_rw_join #(
+   .axi_req_t   ( axi_mst_req_t ),
+   .axi_resp_t  ( axi_mst_rsp_t )
+  ) i_axi_rw_join (
+   .clk_i,
+   .rst_ni,
+   .slv_read_req_i    ( axi_read_req  ),
+   .slv_read_resp_o   ( axi_read_rsp  ),
+   .slv_write_req_i   ( axi_write_req ),
+   .slv_write_resp_o  ( axi_write_rsp ),
+   .mst_req_o         ( axi_mst_req_o ),
+   .mst_resp_i        ( axi_mst_rsp_i )
+  );
+
+endmodule

--- a/hw/cheshire_idma_wrap.sv
+++ b/hw/cheshire_idma_wrap.sv
@@ -2,18 +2,12 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 //
-// Author: Thomas Benz    <tbenz@iis.ee.ethz.ch>
-// Author: Andreas Kuster <kustera@ethz.ch>
-// Author: Paul Scheffler <paulsc@iis.ee.ethz.ch>
-// Author: Chaoqun Liang  <chaoqun.liang@unibo.it>
+// Thomas Benz <tbenz@iis.ee.ethz.ch>
+// Andreas Kuster <kustera@ethz.ch>
+// Paul Scheffler <paulsc@iis.ee.ethz.ch>
+// Chaoqun Liang <chaoqun.liang@unibo.it>
 
-// Description: DMA core wrapper for the CVA6 integration
-
-`include "axi/assign.svh"
-`include "axi/typedef.svh"
-`include "idma/typedef.svh"
-`include "register_interface/typedef.svh"
-
+/// DMA core wrapper for the integration into Cheshire.
 module cheshire_idma_wrap #(
   parameter int unsigned AxiAddrWidth     = 0,
   parameter int unsigned AxiDataWidth     = 0,
@@ -38,6 +32,11 @@ module cheshire_idma_wrap #(
   input  axi_slv_req_t  axi_slv_req_i,
   output axi_slv_rsp_t  axi_slv_rsp_o
 );
+
+  `include "axi/assign.svh"
+  `include "axi/typedef.svh"
+  `include "idma/typedef.svh"
+  `include "register_interface/typedef.svh"
 
   localparam int unsigned IdCounterWidth  = 32;
   localparam int unsigned NumDim          = 2;

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -1422,22 +1422,22 @@ module cheshire_soc import cheshire_pkg::*; #(
       axi_in_req[AxiIn.dma].ar.user = Cfg.AxiUserDefault;
     end
 
-    dma_core_wrap #(
-      .AxiAddrWidth       ( Cfg.AddrWidth           ),
-      .AxiDataWidth       ( Cfg.AxiDataWidth        ),
-      .AxiIdWidth         ( Cfg.AxiMstIdWidth       ),
-      .AxiUserWidth       ( Cfg.AxiUserWidth        ),
-      .AxiSlvIdWidth      ( AxiSlvIdWidth           ),
-      .NumAxInFlight      ( Cfg.DmaNumAxInFlight    ),
-      .MemSysDepth        ( Cfg.DmaMemSysDepth      ),
-      .JobFifoDepth       ( Cfg.DmaJobFifoDepth     ),
-      .RAWCouplingAvail   ( Cfg.DmaRAWCouplingAvail ),
-      .IsTwoD             ( Cfg.DmaConfEnableTwoD   ),
-      .axi_mst_req_t      ( axi_mst_req_t           ),
-      .axi_mst_rsp_t      ( axi_mst_rsp_t           ),
-      .axi_slv_req_t      ( axi_slv_req_t           ),
-      .axi_slv_rsp_t      ( axi_slv_rsp_t           )
-    ) i_dma (
+    cheshire_idma_wrap #(
+      .AxiAddrWidth     ( Cfg.AddrWidth     ),
+      .AxiDataWidth     ( Cfg.AxiDataWidth  ),
+      .AxiIdWidth       ( Cfg.AxiMstIdWidth ),
+      .AxiUserWidth     ( Cfg.AxiUserWidth  ),
+      .AxiSlvIdWidth    ( AxiSlvIdWidth     ),
+      .NumAxInFlight    ( Cfg.DmaNumAxInFlight    ),
+      .MemSysDepth      ( Cfg.DmaMemSysDepth      ),
+      .JobFifoDepth     ( Cfg.DmaJobFifoDepth     ),
+      .RAWCouplingAvail ( Cfg.DmaRAWCouplingAvail ),
+      .IsTwoD           ( Cfg.DmaConfEnableTwoD   ),
+      .axi_mst_req_t    ( axi_mst_req_t ),
+      .axi_mst_rsp_t    ( axi_mst_rsp_t ),
+      .axi_slv_req_t    ( axi_slv_req_t ),
+      .axi_slv_rsp_t    ( axi_slv_rsp_t )
+    ) i_idma (
       .clk_i,
       .rst_ni,
       .testmode_i     ( test_mode_i ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mkdocs
 mkdocs-material
 markdown-grid-tables
 tclint
+flatdict

--- a/sw/include/dif/dma.h
+++ b/sw/include/dif/dma.h
@@ -9,20 +9,18 @@
 #include "regs/idma.h"
 #include "params.h"
 
-#define DMA_SRC_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_SRC_ADDR_REG_OFFSET)
-#define DMA_DST_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_DST_ADDR_REG_OFFSET)
-#define DMA_NUMBYTES_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_NUM_BYTES_REG_OFFSET)
-#define DMA_CONF_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_CONF_REG_OFFSET)
-#define DMA_STATUS_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_STATUS_REG_OFFSET)
-#define DMA_NEXTID_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_NEXT_ID_REG_OFFSET)
-#define DMA_DONE_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_DONE_REG_OFFSET)
-#define DMA_SRC_STRIDE_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_STRIDE_SRC_REG_OFFSET)
-#define DMA_DST_STRIDE_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_STRIDE_DST_REG_OFFSET)
-#define DMA_NUM_REPS_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_FRONTEND_NUM_REPETITIONS_REG_OFFSET)
-
-#define DMA_CONF_DECOUPLE 0
-#define DMA_CONF_DEBURST 0
-#define DMA_CONF_SERIALIZE 0
+#define DMA_SRC_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_SRC_ADDR_LOW_REG_OFFSET)
+#define DMA_DST_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_DST_ADDR_LOW_REG_OFFSET)
+#define DMA_NUMBYTES_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_LENGTH_LOW_REG_OFFSET)
+#define DMA_CONF_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_CONF_REG_OFFSET)
+#define DMA_STATUS_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_STATUS_0_REG_OFFSET)
+#define DMA_NEXTID_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_NEXT_ID_0_REG_OFFSET)
+#define DMA_DONE_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_DONE_ID_0_REG_OFFSET)
+#define DMA_SRC_STRIDE_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_SRC_STRIDE_2_LOW_REG_OFFSET)
+#define DMA_DST_STRIDE_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_DST_STRIDE_2_LOW_REG_OFFSET)
+#define DMA_NUM_REPS_ADDR(BASE) ((void *)BASE + IDMA_REG64_2D_REPS_2_LOW_REG_OFFSET)
+#define DMA_CONF_DECOUPLE_AW 0
+#define DMA_CONF_DECOUPLE_RW 0
 
 #define X(NAME, BASE_ADDR) \
     extern volatile uint64_t *NAME##_dma_src_ptr(void); \
@@ -81,10 +79,8 @@
         *(NAME##_dma_dst_ptr()) = (uint64_t)dst; \
         *(NAME##_dma_num_bytes_ptr()) = size; \
         *(NAME##_dma_num_reps_ptr()) = 0; \
-        *(NAME##_dma_conf_ptr()) = \
-            (DMA_CONF_DECOUPLE << IDMA_REG64_2D_FRONTEND_CONF_DECOUPLE_BIT) | \
-            (DMA_CONF_DEBURST << IDMA_REG64_2D_FRONTEND_CONF_DEBURST_BIT) | \
-            (DMA_CONF_SERIALIZE << IDMA_REG64_2D_FRONTEND_CONF_SERIALIZE_BIT); \
+        *(NAME##_dma_conf_ptr()) = (DMA_CONF_DECOUPLE_AW << IDMA_REG64_2D_CONF_DECOUPLE_AW_BIT) | \
+                                   (DMA_CONF_DECOUPLE_RW << IDMA_REG64_2D_CONF_DECOUPLE_AW_BIT); \
         return *(NAME##_dma_nextid_ptr()); \
     } \
 \
@@ -101,10 +97,9 @@
         *(NAME##_dma_src_ptr()) = (uint64_t)src; \
         *(NAME##_dma_dst_ptr()) = (uint64_t)dst; \
         *(NAME##_dma_num_bytes_ptr()) = size; \
-        *(NAME##_dma_conf_ptr()) = \
-            (DMA_CONF_DECOUPLE << IDMA_REG64_2D_FRONTEND_CONF_DECOUPLE_BIT) | \
-            (DMA_CONF_DEBURST << IDMA_REG64_2D_FRONTEND_CONF_DEBURST_BIT) | \
-            (DMA_CONF_SERIALIZE << IDMA_REG64_2D_FRONTEND_CONF_SERIALIZE_BIT); \
+        *(NAME##_dma_conf_ptr()) = (DMA_CONF_DECOUPLE_AW << IDMA_REG64_2D_CONF_DECOUPLE_AW_BIT) | \
+                                   (DMA_CONF_DECOUPLE_RW << IDMA_REG64_2D_CONF_DECOUPLE_AW_BIT) | \
+                                   (1 << IDMA_REG64_2D_CONF_ENABLE_ND_BIT); \
         *(NAME##_dma_src_stride_ptr()) = src_stride; \
         *(NAME##_dma_dst_stride_ptr()) = dst_stride; \
         *(NAME##_dma_num_reps_ptr()) = num_reps; \

--- a/sw/include/regs/idma.h
+++ b/sw/include/regs/idma.h
@@ -1,57 +1,302 @@
-// Generated register defines for idma_reg64_2d_frontend
+// Generated register defines for idma_reg64_2d
 
 // Copyright information found in source file:
-// Copyright 2022 ETH Zurich and University of Bologna.
+// Copyright 2023 ETH Zurich and University of Bologna.
 
 // Licensing information found in source file:
-// Licensed under Solderpad Hardware License, Version 0.51
+// 
 // SPDX-License-Identifier: SHL-0.51
 
-#ifndef _IDMA_REG64_2D_FRONTEND_REG_DEFS_
-#define _IDMA_REG64_2D_FRONTEND_REG_DEFS_
+#ifndef _IDMA_REG64_2D_REG_DEFS_
+#define _IDMA_REG64_2D_REG_DEFS_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+// Number of dimensions available
+#define IDMA_REG64_2D_PARAM_NUM_DIMS 2
+
 // Register width
-#define IDMA_REG64_2D_FRONTEND_PARAM_REG_WIDTH 64
-
-// Source Address
-#define IDMA_REG64_2D_FRONTEND_SRC_ADDR_REG_OFFSET 0x0
-
-// Destination Address
-#define IDMA_REG64_2D_FRONTEND_DST_ADDR_REG_OFFSET 0x8
-
-// Number of bytes
-#define IDMA_REG64_2D_FRONTEND_NUM_BYTES_REG_OFFSET 0x10
+#define IDMA_REG64_2D_PARAM_REG_WIDTH 32
 
 // Configuration Register for DMA settings
-#define IDMA_REG64_2D_FRONTEND_CONF_REG_OFFSET 0x18
-#define IDMA_REG64_2D_FRONTEND_CONF_DECOUPLE_BIT 0
-#define IDMA_REG64_2D_FRONTEND_CONF_DEBURST_BIT 1
-#define IDMA_REG64_2D_FRONTEND_CONF_SERIALIZE_BIT 2
+#define IDMA_REG64_2D_CONF_REG_OFFSET 0x0
+#define IDMA_REG64_2D_CONF_DECOUPLE_AW_BIT 0
+#define IDMA_REG64_2D_CONF_DECOUPLE_RW_BIT 1
+#define IDMA_REG64_2D_CONF_SRC_REDUCE_LEN_BIT 2
+#define IDMA_REG64_2D_CONF_DST_REDUCE_LEN_BIT 3
+#define IDMA_REG64_2D_CONF_SRC_MAX_LLEN_MASK 0x7
+#define IDMA_REG64_2D_CONF_SRC_MAX_LLEN_OFFSET 4
+#define IDMA_REG64_2D_CONF_SRC_MAX_LLEN_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_CONF_SRC_MAX_LLEN_MASK, .index = IDMA_REG64_2D_CONF_SRC_MAX_LLEN_OFFSET })
+#define IDMA_REG64_2D_CONF_DST_MAX_LLEN_MASK 0x7
+#define IDMA_REG64_2D_CONF_DST_MAX_LLEN_OFFSET 7
+#define IDMA_REG64_2D_CONF_DST_MAX_LLEN_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_CONF_DST_MAX_LLEN_MASK, .index = IDMA_REG64_2D_CONF_DST_MAX_LLEN_OFFSET })
+#define IDMA_REG64_2D_CONF_ENABLE_ND_BIT 10
+
+// DMA Status (common parameters)
+#define IDMA_REG64_2D_STATUS_BUSY_FIELD_WIDTH 10
+#define IDMA_REG64_2D_STATUS_BUSY_FIELDS_PER_REG 3
+#define IDMA_REG64_2D_STATUS_MULTIREG_COUNT 16
 
 // DMA Status
-#define IDMA_REG64_2D_FRONTEND_STATUS_REG_OFFSET 0x20
-#define IDMA_REG64_2D_FRONTEND_STATUS_BUSY_BIT 0
+#define IDMA_REG64_2D_STATUS_0_REG_OFFSET 0x4
+#define IDMA_REG64_2D_STATUS_0_BUSY_0_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_0_BUSY_0_OFFSET 0
+#define IDMA_REG64_2D_STATUS_0_BUSY_0_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_0_BUSY_0_MASK, .index = IDMA_REG64_2D_STATUS_0_BUSY_0_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_1_REG_OFFSET 0x8
+#define IDMA_REG64_2D_STATUS_1_BUSY_1_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_1_BUSY_1_OFFSET 0
+#define IDMA_REG64_2D_STATUS_1_BUSY_1_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_1_BUSY_1_MASK, .index = IDMA_REG64_2D_STATUS_1_BUSY_1_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_2_REG_OFFSET 0xc
+#define IDMA_REG64_2D_STATUS_2_BUSY_2_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_2_BUSY_2_OFFSET 0
+#define IDMA_REG64_2D_STATUS_2_BUSY_2_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_2_BUSY_2_MASK, .index = IDMA_REG64_2D_STATUS_2_BUSY_2_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_3_REG_OFFSET 0x10
+#define IDMA_REG64_2D_STATUS_3_BUSY_3_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_3_BUSY_3_OFFSET 0
+#define IDMA_REG64_2D_STATUS_3_BUSY_3_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_3_BUSY_3_MASK, .index = IDMA_REG64_2D_STATUS_3_BUSY_3_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_4_REG_OFFSET 0x14
+#define IDMA_REG64_2D_STATUS_4_BUSY_4_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_4_BUSY_4_OFFSET 0
+#define IDMA_REG64_2D_STATUS_4_BUSY_4_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_4_BUSY_4_MASK, .index = IDMA_REG64_2D_STATUS_4_BUSY_4_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_5_REG_OFFSET 0x18
+#define IDMA_REG64_2D_STATUS_5_BUSY_5_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_5_BUSY_5_OFFSET 0
+#define IDMA_REG64_2D_STATUS_5_BUSY_5_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_5_BUSY_5_MASK, .index = IDMA_REG64_2D_STATUS_5_BUSY_5_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_6_REG_OFFSET 0x1c
+#define IDMA_REG64_2D_STATUS_6_BUSY_6_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_6_BUSY_6_OFFSET 0
+#define IDMA_REG64_2D_STATUS_6_BUSY_6_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_6_BUSY_6_MASK, .index = IDMA_REG64_2D_STATUS_6_BUSY_6_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_7_REG_OFFSET 0x20
+#define IDMA_REG64_2D_STATUS_7_BUSY_7_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_7_BUSY_7_OFFSET 0
+#define IDMA_REG64_2D_STATUS_7_BUSY_7_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_7_BUSY_7_MASK, .index = IDMA_REG64_2D_STATUS_7_BUSY_7_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_8_REG_OFFSET 0x24
+#define IDMA_REG64_2D_STATUS_8_BUSY_8_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_8_BUSY_8_OFFSET 0
+#define IDMA_REG64_2D_STATUS_8_BUSY_8_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_8_BUSY_8_MASK, .index = IDMA_REG64_2D_STATUS_8_BUSY_8_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_9_REG_OFFSET 0x28
+#define IDMA_REG64_2D_STATUS_9_BUSY_9_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_9_BUSY_9_OFFSET 0
+#define IDMA_REG64_2D_STATUS_9_BUSY_9_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_9_BUSY_9_MASK, .index = IDMA_REG64_2D_STATUS_9_BUSY_9_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_10_REG_OFFSET 0x2c
+#define IDMA_REG64_2D_STATUS_10_BUSY_10_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_10_BUSY_10_OFFSET 0
+#define IDMA_REG64_2D_STATUS_10_BUSY_10_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_10_BUSY_10_MASK, .index = IDMA_REG64_2D_STATUS_10_BUSY_10_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_11_REG_OFFSET 0x30
+#define IDMA_REG64_2D_STATUS_11_BUSY_11_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_11_BUSY_11_OFFSET 0
+#define IDMA_REG64_2D_STATUS_11_BUSY_11_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_11_BUSY_11_MASK, .index = IDMA_REG64_2D_STATUS_11_BUSY_11_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_12_REG_OFFSET 0x34
+#define IDMA_REG64_2D_STATUS_12_BUSY_12_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_12_BUSY_12_OFFSET 0
+#define IDMA_REG64_2D_STATUS_12_BUSY_12_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_12_BUSY_12_MASK, .index = IDMA_REG64_2D_STATUS_12_BUSY_12_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_13_REG_OFFSET 0x38
+#define IDMA_REG64_2D_STATUS_13_BUSY_13_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_13_BUSY_13_OFFSET 0
+#define IDMA_REG64_2D_STATUS_13_BUSY_13_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_13_BUSY_13_MASK, .index = IDMA_REG64_2D_STATUS_13_BUSY_13_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_14_REG_OFFSET 0x3c
+#define IDMA_REG64_2D_STATUS_14_BUSY_14_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_14_BUSY_14_OFFSET 0
+#define IDMA_REG64_2D_STATUS_14_BUSY_14_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_14_BUSY_14_MASK, .index = IDMA_REG64_2D_STATUS_14_BUSY_14_OFFSET })
+
+// DMA Status
+#define IDMA_REG64_2D_STATUS_15_REG_OFFSET 0x40
+#define IDMA_REG64_2D_STATUS_15_BUSY_15_MASK 0x3ff
+#define IDMA_REG64_2D_STATUS_15_BUSY_15_OFFSET 0
+#define IDMA_REG64_2D_STATUS_15_BUSY_15_FIELD \
+  ((bitfield_field32_t) { .mask = IDMA_REG64_2D_STATUS_15_BUSY_15_MASK, .index = IDMA_REG64_2D_STATUS_15_BUSY_15_OFFSET })
 
 // Next ID, launches transfer, returns 0 if transfer not set up properly.
-#define IDMA_REG64_2D_FRONTEND_NEXT_ID_REG_OFFSET 0x28
+// (common parameters)
+#define IDMA_REG64_2D_NEXT_ID_NEXT_ID_FIELD_WIDTH 32
+#define IDMA_REG64_2D_NEXT_ID_NEXT_ID_FIELDS_PER_REG 1
+#define IDMA_REG64_2D_NEXT_ID_MULTIREG_COUNT 16
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_0_REG_OFFSET 0x44
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_1_REG_OFFSET 0x48
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_2_REG_OFFSET 0x4c
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_3_REG_OFFSET 0x50
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_4_REG_OFFSET 0x54
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_5_REG_OFFSET 0x58
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_6_REG_OFFSET 0x5c
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_7_REG_OFFSET 0x60
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_8_REG_OFFSET 0x64
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_9_REG_OFFSET 0x68
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_10_REG_OFFSET 0x6c
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_11_REG_OFFSET 0x70
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_12_REG_OFFSET 0x74
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_13_REG_OFFSET 0x78
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_14_REG_OFFSET 0x7c
+
+// Next ID, launches transfer, returns 0 if transfer not set up properly.
+#define IDMA_REG64_2D_NEXT_ID_15_REG_OFFSET 0x80
+
+// Get ID of finished transactions. (common parameters)
+#define IDMA_REG64_2D_DONE_ID_DONE_ID_FIELD_WIDTH 32
+#define IDMA_REG64_2D_DONE_ID_DONE_ID_FIELDS_PER_REG 1
+#define IDMA_REG64_2D_DONE_ID_MULTIREG_COUNT 16
 
 // Get ID of finished transactions.
-#define IDMA_REG64_2D_FRONTEND_DONE_REG_OFFSET 0x30
+#define IDMA_REG64_2D_DONE_ID_0_REG_OFFSET 0x84
 
-// Source Stride
-#define IDMA_REG64_2D_FRONTEND_STRIDE_SRC_REG_OFFSET 0x38
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_1_REG_OFFSET 0x88
 
-// Destination Stride
-#define IDMA_REG64_2D_FRONTEND_STRIDE_DST_REG_OFFSET 0x40
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_2_REG_OFFSET 0x8c
 
-// Number of 2D repetitions
-#define IDMA_REG64_2D_FRONTEND_NUM_REPETITIONS_REG_OFFSET 0x48
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_3_REG_OFFSET 0x90
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_4_REG_OFFSET 0x94
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_5_REG_OFFSET 0x98
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_6_REG_OFFSET 0x9c
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_7_REG_OFFSET 0xa0
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_8_REG_OFFSET 0xa4
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_9_REG_OFFSET 0xa8
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_10_REG_OFFSET 0xac
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_11_REG_OFFSET 0xb0
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_12_REG_OFFSET 0xb4
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_13_REG_OFFSET 0xb8
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_14_REG_OFFSET 0xbc
+
+// Get ID of finished transactions.
+#define IDMA_REG64_2D_DONE_ID_15_REG_OFFSET 0xc0
+
+// Low destination address
+#define IDMA_REG64_2D_DST_ADDR_LOW_REG_OFFSET 0xd0
+
+// High destination address
+#define IDMA_REG64_2D_DST_ADDR_HIGH_REG_OFFSET 0xd4
+
+// Low source address
+#define IDMA_REG64_2D_SRC_ADDR_LOW_REG_OFFSET 0xd8
+
+// High source address
+#define IDMA_REG64_2D_SRC_ADDR_HIGH_REG_OFFSET 0xdc
+
+// Low transfer length in byte
+#define IDMA_REG64_2D_LENGTH_LOW_REG_OFFSET 0xe0
+
+// High transfer length in byte
+#define IDMA_REG64_2D_LENGTH_HIGH_REG_OFFSET 0xe4
+
+// Low destination stride dimension 2
+#define IDMA_REG64_2D_DST_STRIDE_2_LOW_REG_OFFSET 0xe8
+
+// High destination stride dimension 2
+#define IDMA_REG64_2D_DST_STRIDE_2_HIGH_REG_OFFSET 0xec
+
+// Low source stride dimension 2
+#define IDMA_REG64_2D_SRC_STRIDE_2_LOW_REG_OFFSET 0xf0
+
+// High source stride dimension 2
+#define IDMA_REG64_2D_SRC_STRIDE_2_HIGH_REG_OFFSET 0xf4
+
+// Low number of repetitions dimension 2
+#define IDMA_REG64_2D_REPS_2_LOW_REG_OFFSET 0xf8
+
+// High number of repetitions dimension 2
+#define IDMA_REG64_2D_REPS_2_HIGH_REG_OFFSET 0xfc
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-#endif  // _IDMA_REG64_2D_FRONTEND_REG_DEFS_
-// End generated register defines for idma_reg64_2d_frontend
+#endif  // _IDMA_REG64_2D_REG_DEFS_
+// End generated register defines for idma_reg64_2d

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -79,7 +79,7 @@ endef
 $(eval $(call chs_sw_gen_hdr_rule,clint,$(CLINTROOT)/src/clint.hjson $(CLINTROOT)/.generated))
 $(eval $(call chs_sw_gen_hdr_rule,serial_link,$(CHS_ROOT)/hw/serial_link.hjson $(CHS_SLINK_DIR)/.generated))
 $(eval $(call chs_sw_gen_hdr_rule,axi_vga,$(AXI_VGA_ROOT)/data/axi_vga.hjson $(AXI_VGA_ROOT)/.generated))
-$(eval $(call chs_sw_gen_hdr_rule,idma,$(IDMA_ROOT)/src/frontends/register_64bit_2d/idma_reg64_2d_frontend.hjson))
+$(eval $(call chs_sw_gen_hdr_rule,idma,$(IDMA_ROOT)/target/rtl/idma_reg64_2d.hjson))
 $(eval $(call chs_sw_gen_hdr_rule,axi_llc,$(CHS_LLC_DIR)/data/axi_llc_regs.hjson))
 $(eval $(call chs_sw_gen_hdr_rule,cheshire,$(CHS_ROOT)/hw/regs/cheshire_regs.hjson))
 $(eval $(call chs_sw_gen_hdr_rule,axi_rt,$(AXIRTROOT)/src/regs/axi_rt.hjson $(AXIRTROOT)/.generated))

--- a/sw/tests/dma_2d.c
+++ b/sw/tests/dma_2d.c
@@ -1,0 +1,40 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Simple test for iDMA. This is intended *only for execution from SPM*.
+
+#include "util.h"
+#include "dif/clint.h"
+#include "dif/dma.h"
+
+int main(void) {
+    volatile char src_cached[] = "This is a DMA test";
+    volatile char gold[] = "This ishis is is is as is a DMA test!";
+
+    // Allocate destination memory in SPM
+    volatile char dst_cached[sizeof(gold)];
+
+    // Get pointer to uncached SPM source and destination
+    volatile char *src = src_cached + 0x04000000;
+    volatile char *dst = dst_cached + 0x04000000;
+
+    // Copy from cached to uncached source to ensure it is DMA-accessible
+    for (unsigned i = 0; i < sizeof(src_cached); ++i) src[i] = src_cached[i];
+
+    // Pre-write finishing "!\0" to guard against overlength transfers
+    dst[sizeof(gold) - 2] = '!';
+    dst[sizeof(gold) - 1] = '\0';
+
+    // Issue blocking 2D memcpy (exclude null terminator from source)
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)dst, (uintptr_t)(void *)src, sizeof(src_cached) - 4, 7,
+                          1, 4);
+
+    // Check destination string
+    int errors = sizeof(gold);
+    for (unsigned i = 0; i < sizeof(gold); ++i) errors -= (dst[i] == gold[i]);
+
+    return errors;
+}

--- a/target/xilinx/xilinx.mk
+++ b/target/xilinx/xilinx.mk
@@ -41,7 +41,7 @@ CHS_XILINX_IPS_genesys2 := clkwiz vio mig7s
 CHS_XILINX_IPS_vcu128   := clkwiz vio ddr4
 
 $(CHS_XILINX_DIR)/scripts/add_sources.%.tcl: $(CHS_ROOT)/Bender.yml
-	$(BENDER) script vivado -t fpga -t cv64a6_imafdcsclic_sv39 -t cva6 -t $* > $@
+	$(BENDER) script vivado -t fpga -t $* $(CHS_BENDER_RTL_FLAGS) > $@
 
 define chs_xilinx_bit_rule
 $$(CHS_XILINX_DIR)/out/%.$(1).bit: \


### PR DESCRIPTION
* Update iDMA to `v0.6.3`, including wrapper removed upstream here.
* Add `dma_2d` test.
* Add `CHS_BENDER_RTL_FLAGS` as common source of RTL Bender flags.