### PR TITLE
sw/link: Avoid incorrect `.bss` delimiters

### DIFF
--- a/sw/link/dram.ld
+++ b/sw/link/dram.ld
@@ -28,16 +28,14 @@ SECTIONS {
     *(.sdata.*)
   } > dram
 
-  . = ALIGN(32);
-  __bss_start = .;
-  .bss : {
+  .bss : ALIGN(16) {
+    __bss_start = .;
     *(.bss)
     *(.bss.*)
     *(.sbss)
     *(.sbss.*)
+    __bss_end = .;
   } > dram
-  . = ALIGN(32);
-  __bss_end = .;
 
   .bulk : ALIGN(16) {
     *(.bulk)

--- a/sw/link/rom.ld
+++ b/sw/link/rom.ld
@@ -27,14 +27,12 @@ SECTIONS {
   } > spm AT>extrom
 
   /* BSS is not loaded, but initialized by CRT0 */
-  . = ALIGN(32);
-  __bss_start = .;
-  .bss : {
+  .bss : ALIGN(16) {
+    __bss_start = .;
     *(.bss)
     *(.bss.*)
     *(.sbss)
     *(.sbss.*)
+    __bss_end = .;
   } > spm
-  . = ALIGN(32);
-  __bss_end = .;
 }

--- a/sw/link/spm.ld
+++ b/sw/link/spm.ld
@@ -26,16 +26,14 @@ SECTIONS {
     *(.sdata.*)
   } > spm
 
-  . = ALIGN(32);
-  __bss_start = .;
-  .bss : {
+  .bss : ALIGN(16) {
+    __bss_start = .;
     *(.bss)
     *(.bss.*)
     *(.sbss)
     *(.sbss.*)
+    __bss_end = .;
   } > spm
-  . = ALIGN(32);
-  __bss_end = .;
 
   .bulk : ALIGN(16) {
     *(.bulk)


### PR DESCRIPTION
Under some conditions, `__bss_start` and `__bss_end` would not correctly delimit `.bss`.