### PR TITLE
hw: Fix CVA6 debug module addresses

### DIFF
--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -521,8 +521,8 @@ package cheshire_pkg;
       EnableAccelerator     : 0,
       RVS                   : 1,
       RVU                   : 1,
-      HaltAddress           : AmDbg + 'h800,
-      ExceptionAddress      : AmDbg + 'h808,
+      HaltAddress           : 'h800, // Relative to AmDbg
+      ExceptionAddress      : 'h810, // Relative to AmDbg
       RASDepth              : cfg.Cva6RASDepth,
       BTBEntries            : cfg.Cva6BTBEntries,
       BHTEntries            : cfg.Cva6BHTEntries,


### PR DESCRIPTION
This fixes two errors in the debug module addresses passed to CVA6:

1. `HaltAddress` and `ExceptionAddress` are assumed to be relative to `DmBaseAddress`, see [here](https://github.com/pulp-platform/cva6/blob/99ae53bde1a94b90c1d9bbbe7fe272a9336200a6/core/frontend/frontend.sv#L380) and
[here](https://github.com/pulp-platform/cva6/blob/99ae53bde1a94b90c1d9bbbe7fe272a9336200a6/core/csr_regfile.sv#L2295). In Cheshire, they are currently assigned their absolute address. Coincidentally, this currently does not cause any issues since `AmDbg = '0`,

2. `ExceptionAddress` was changed from `0x808` to `0x810` in https://github.com/pulp-platform/riscv-dbg/pull/145, which is included in the debug module version used in Cheshire. **This means that exceptions in debug mode currently cause CVA6 to jump to `resume` and return from debug mode instead of handling the exception**, which breaks several openocd commands that rely on exceptions to discover CSR availabilities.