### PR TITLE
Add LLC bypass region for Carfield

### DIFF
--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -162,6 +162,8 @@ package cheshire_pkg;
     bit     LlcOutConnect;
     doub_bt LlcOutRegionStart;
     doub_bt LlcOutRegionEnd;
+    doub_bt LlcBypassRegionStart;
+    doub_bt LlcBypassRegionEnd;
     dw_bt   LlcUserMsb;
     dw_bt   LlcUserLsb;
     // Parameters for VGA
@@ -348,6 +350,8 @@ package cheshire_pkg;
     // own Xbar output with the specified region iff it is connected.
     if (cfg.LlcOutConnect) begin i++; r++; ret.llc = i;
         ret.map[r] = '{i, cfg.LlcOutRegionStart, cfg.LlcOutRegionEnd}; end
+    if (cfg.LlcOutConnect) begin r++;
+        ret.map[r] = '{i, cfg.LlcBypassRegionStart, cfg.LlcBypassRegionEnd}; end
     // We can only internally map the SPM region if an LLC exists.
     // Otherwise, we assume external ports map and back the SPM region.
     // We map both the cached and uncached regions.
@@ -589,6 +593,8 @@ package cheshire_pkg;
     LlcOutConnect     : 1,
     LlcOutRegionStart : 'h8000_0000,
     LlcOutRegionEnd   : 'h1_0000_0000,
+    LlcBypassRegionStart : 'h2_8000_0000,
+    LlcBypassRegionEnd   : 'h3_0000_0000,
     LlcUserMsb        : 0,
     LlcUserLsb        : 0,
     // LLC Partitioning

--- a/target/xilinx/src/cheshire_top_xilinx.sv
+++ b/target/xilinx/src/cheshire_top_xilinx.sv
@@ -123,6 +123,8 @@ module cheshire_top_xilinx
     LlcOutConnect     : 1,
     LlcOutRegionStart : 'h8000_0000,
     LlcOutRegionEnd   : 'h1_0000_0000,
+    LlcBypassRegionStart : 'h2_8000_0000,
+    LlcBypassRegionEnd   : 'h3_0000_0000,
     LlcUserMsb        : 0,
     LlcUserLsb        : 0,
     // LLC partitioning


### PR DESCRIPTION
The region at [0x2_8000_0000 ; 0x3_0000_0000[ can be used to bypass the LLC when the LLC is enabled.
This is useful to speedup device DMA when LLC is enabled (of course requires managing LLC flushes in software).
