### PR TITLE
sw/tests: Do not print null terminators

### DIFF
--- a/sw/tests/axirt_hello.spm.c
+++ b/sw/tests/axirt_hello.spm.c
@@ -55,7 +55,7 @@ int main(void) {
 
     // Configure UART and write message
     uart_init(&__base_uart, reset_freq, __BOOT_BAUDRATE);
-    uart_write_str(&__base_uart, str, sizeof(str));
+    uart_write_str(&__base_uart, str, sizeof(str) - 1);
     uart_write_flush(&__base_uart);
     return 0;
 }

--- a/sw/tests/helloworld.c
+++ b/sw/tests/helloworld.c
@@ -17,7 +17,7 @@ int main(void) {
     uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
     uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
     uart_init(&__base_uart, reset_freq, __BOOT_BAUDRATE);
-    uart_write_str(&__base_uart, str, sizeof(str));
+    uart_write_str(&__base_uart, str, sizeof(str) - 1);
     uart_write_flush(&__base_uart);
     return 0;
 }


### PR DESCRIPTION
sizeof(char[]) includes the null-terminator.