### PR TITLE
util/openocd: fix deprecation warnings, fix virtaddr translation

### DIFF
--- a/util/openocd.common.tcl
+++ b/util/openocd.common.tcl
@@ -5,8 +5,8 @@
 # Common OpenOCD script for Cheshire.
 
 transport select jtag
-telnet_port disabled
-tcl_port disabled
+telnet port disabled
+tcl port disabled
 reset_config none
 
 set _CHIPNAME riscv
@@ -15,13 +15,12 @@ jtag newtap $_CHIPNAME cpu -irlen ${irlen} -expected-id 0x1c5e5db3
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME -coreid 0
 
-gdb_report_data_abort enable
-gdb_report_register_access_error enable
+gdb report_data_abort enable
+gdb report_register_access_error enable
 
-riscv set_reset_timeout_sec 120
 riscv set_command_timeout_sec 120
 
-riscv set_prefer_sba off
+riscv set_mem_access progbuf abstract
 
 # Exit when debugger detaches
 $_TARGETNAME configure -event gdb-detach {
@@ -30,9 +29,9 @@ $_TARGETNAME configure -event gdb-detach {
 }
 
 # Try enabling address translation (only works for newer versions)
-if { [catch { riscv set_enable_virtual on } ] } {
+if { [catch { riscv virt2phys_mode sw } ] } {
     echo "Warning: This version of OpenOCD does not support address translation.\
-        To debug on virtual addresses, please update to the latest version."
+          To debug on virtual addresses, please update to the latest version."
 }
 
 init

--- a/util/openocd.genesys2.tcl
+++ b/util/openocd.genesys2.tcl
@@ -4,11 +4,11 @@
 #
 # OpenOCD script for Cheshire on Genesys2.
 
-adapter_khz 8000
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-ftdi_layout_init 0x00e8 0x60eb
-ftdi_channel 0
+adapter speed 8000
+adapter driver ftdi
+ftdi vid_pid 0x0403 0x6010
+ftdi layout_init 0x00e8 0x60eb
+ftdi channel 0
 set irlen 5
 
 source [file dirname [info script]]/openocd.common.tcl


### PR DESCRIPTION
A bunch of these commands print deprecation warnings with recent-ish versions of openocd, and the virtual address translation using hw translation seems to be quite broken.

cc @niwis where we spent some time debugging these issues.