### PR TITLE
hw: Fix uncached SPM execute region

### DIFF
--- a/cheshire.mk
+++ b/cheshire.mk
@@ -63,7 +63,7 @@ chs-clean-deps:
 ######################
 
 CHS_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/cheshire-nonfree.git
-CHS_NONFREE_COMMIT ?= 99aa8d9
+CHS_NONFREE_COMMIT ?= 92f6f02
 
 CHS_PHONY += chs-nonfree-init
 chs-nonfree-init:

--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -280,11 +280,11 @@ package cheshire_pkg;
   localparam doub_bt AmSlink  = 'h0300_6000;
   localparam doub_bt AmBusErr = 'h0300_9000;
   localparam doub_bt AmSpm    = 'h1000_0000;  // Cached region at bottom, uncached on top
+  localparam doub_bt AmSpmUnc = 'h1400_0000;
   localparam doub_bt AmClic   = 'h0800_0000;
 
   // Static masks
-  localparam doub_bt AmSpmBaseUncached = 'h1400_0000;
-  localparam doub_bt AmSpmRegionMask   = 'h03FF_FFFF;
+  localparam doub_bt AmSpmRegionMask = 'h03FF_FFFF;
 
   // Reg bus error unit indices
   localparam int unsigned RegBusErrVga        = 0;
@@ -355,7 +355,7 @@ package cheshire_pkg;
     if (cfg.LlcNotBypass) begin
       ret.spm = i;
       r++; ret.map[r] = '{i, AmSpm, AmSpm + SizeSpm};
-      r++; ret.map[r] = '{i, AmSpm + 'h0400_0000, AmSpm + 'h0400_0000 + SizeSpm};
+      r++; ret.map[r] = '{i, AmSpmUnc, AmSpmUnc + SizeSpm};
     end
     if (cfg.Dma)          begin i++; r++; ret.dma = i; ret.map[r] = '{i, 'h0100_0000, 'h0100_1000}; end
     if (cfg.SerialLink)   begin i++; r++; ret.slink = i;
@@ -537,9 +537,9 @@ package cheshire_pkg;
       NrNonIdempotentRules  : 2,   // Periphs, ExtNonCIE
       NonIdempotentAddrBase : {64'h0000_0000, NoCieBase},
       NonIdempotentLength   : {64'h1000_0000, 64'h6000_0000 - cfg.Cva6ExtCieLength},
-      NrExecuteRegionRules  : 5,   // Debug, Bootrom, AllSPM, LLCOut, ExtCIE
-      ExecuteRegionAddrBase : {AmDbg, AmBrom, AmSpm, cfg.LlcOutRegionStart, CieBase},
-      ExecuteRegionLength   : {64'h40000, 64'h40000, 2*SizeSpm, SizeLlcOut, cfg.Cva6ExtCieLength},
+      NrExecuteRegionRules  : 6,   // Debug, Bootrom, SPM, SPM Uncached, LLCOut, ExtCIE
+      ExecuteRegionAddrBase : {AmDbg,     AmBrom,    AmSpm,   AmSpmUnc, cfg.LlcOutRegionStart, CieBase},
+      ExecuteRegionLength   : {64'h40000, 64'h40000, SizeSpm, SizeSpm,  SizeLlcOut,            cfg.Cva6ExtCieLength},
       NrCachedRegionRules   : 3,   // CachedSPM, LLCOut, ExtCIE
       CachedRegionAddrBase  : {AmSpm,   cfg.LlcOutRegionStart,  CieBase},
       CachedRegionLength    : {SizeSpm, SizeLlcOut,             cfg.Cva6ExtCieLength},

--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -501,9 +501,9 @@ module cheshire_soc import cheshire_pkg::*; #(
     // This is necessary for routing in the LLC-internal interconnect.
     always_comb begin
       axi_llc_remap_req = axi_llc_cut_req;
-      if ((axi_llc_cut_req.aw.addr & ~AmSpmRegionMask) == (AmSpmBaseUncached & ~AmSpmRegionMask))
+      if ((axi_llc_cut_req.aw.addr & ~AmSpmRegionMask) == (AmSpmUnc & ~AmSpmRegionMask))
         axi_llc_remap_req.aw.addr  = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.aw.addr);
-      if ((axi_llc_cut_req.ar.addr & ~AmSpmRegionMask) == (AmSpmBaseUncached & ~AmSpmRegionMask))
+      if ((axi_llc_cut_req.ar.addr & ~AmSpmRegionMask) == (AmSpmUnc & ~AmSpmRegionMask))
         axi_llc_remap_req.ar.addr = AmSpm | (AmSpmRegionMask & axi_llc_cut_req.ar.addr);
       axi_llc_cut_rsp = axi_llc_remap_rsp;
     end

--- a/sw/lib/crt0.S
+++ b/sw/lib/crt0.S
@@ -179,4 +179,5 @@ _trap_handler_wrap:
 .weak trap_vector
 .align 4
 trap_vector:
+    wfi
     j trap_vector

--- a/sw/tests/axirt_budget.spm.c
+++ b/sw/tests/axirt_budget.spm.c
@@ -87,7 +87,7 @@ int main(void) {
     // Wait for writes, then launch blocking DMA transfer
     fence();
     sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src, sizeof(golden), 0,
-                          0, 1);
+                          0, 1, DMA_CONF_DECOUPLE_ALL);
 
     // Check DMA transfers against gold.
     for (int i = 0; i < DMA_NUM_BEATS; i++) CHECK_ASSERT(20 + i, dma_dst[i] == golden[i]);

--- a/sw/tests/axirt_budget_isolate.spm.c
+++ b/sw/tests/axirt_budget_isolate.spm.c
@@ -83,7 +83,7 @@ int main(void) {
     // Wait for writes, then launch blocking DMA transfer
     fence();
     sys_dma_2d_blk_memcpy((uintptr_t)(void *)dma_dst, (uintptr_t)(void *)dma_src,
-                          sizeof(dma_src_cached), 0, 0, DMA_NUM_REPS);
+                          sizeof(dma_src_cached), 0, 0, DMA_NUM_REPS, DMA_CONF_DECOUPLE_ALL);
 
     // Poll isolate to check if AXI-REALM isolates the dma when the budget is
     // exceeded. Should return 1 if dma is isolated.

--- a/sw/tests/dma_2d.spm.c
+++ b/sw/tests/dma_2d.spm.c
@@ -33,7 +33,7 @@ int main(void) {
 
     // Issue blocking 2D memcpy (exclude null terminator from source)
     sys_dma_2d_blk_memcpy((uintptr_t)(void *)dst, (uintptr_t)(void *)src, sizeof(src_cached) - 4, 7,
-                          1, 4);
+                          1, 4, DMA_CONF_DECOUPLE_NONE);
 
     // Check destination string
     int errors = sizeof(gold);

--- a/sw/tests/spm_uncached.spm.c
+++ b/sw/tests/spm_uncached.spm.c
@@ -1,0 +1,45 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Paul Scheffler <paulsc@iis.ee.ethz.ch>
+//
+// Simple test to check that execution from uncached SPM is possible and indeed uncached.
+
+#include "dif/dma.h"
+#include "regs/cheshire.h"
+#include "util.h"
+
+typedef void (*fptr)(volatile int *volatile);
+
+void __attribute__((aligned(64))) __attribute__((visibility("hidden"))) __attribute__((noinline))
+payload1(volatile int *volatile ret) {
+    *ret = 1;
+}
+
+void __attribute__((aligned(64))) __attribute__((visibility("hidden"))) __attribute__((noinline))
+payload2(volatile int *volatile ret) {
+    *ret = 2;
+}
+
+int main(void) {
+    // Immediately return an error if DMA is not present
+    CHECK_ASSERT(-1, chs_hw_feature_present(CHESHIRE_HW_FEATURES_DMA_BIT));
+
+    // Execute payload1; this should cache it.
+    volatile int outcome1;
+    payload1(&outcome1);
+
+    // Copy payload2 to payload1 using the DMA, overwriting it.
+    sys_dma_2d_blk_memcpy((uintptr_t)(void *)(&payload1), (uintptr_t)(void *)(&payload2), 64, 0, 0,
+                          1, DMA_CONF_DECOUPLE_ALL);
+
+    // Execute payload1 again from uncached SPM.
+    // Since this region is uncached, the DMA-overwritten code should run and 2 should be returned.
+    fptr payload1_unc = (void *)(&payload1) + 0x04000000;
+    volatile int outcome2;
+    payload1_unc(&outcome2);
+
+    // Check that the outcomes were as expected.
+    return (outcome1 + outcome2 != 3);
+}


### PR DESCRIPTION
Fixes #188.

Changes:

* Add uncached SPM as its own executable region (simplify parameterization a bit in the process)
* Add a test `spm_uncached` executing from uncached SPM and verifying it is not cached

Additional changes:

* Add argument to DMA calls to enable dynamic use of decoupling flags (this breaks DMA API compatibility)
* Add `wfi` to default trap handler (this quiets core on exceptions, including on unhandled `ebreak`)