### PR TITLE
target/sim: Split serial link preload at page boundaries

### DIFF
--- a/target/sim/src/vip_cheshire_soc.sv
+++ b/target/sim/src/vip_cheshire_soc.sv
@@ -900,6 +900,10 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
         addr_t  addr_cur  = sec_addr + offset;
         remain    = sec_len - offset;
         page_left = 4096 - (addr_cur & 12'hFFF);
+        if (offset != 0) begin
+          $display("[SLINK] - %0d/%0d bytes (%0d%%)", offset, sec_len,
+                   offset*100/(sec_len > 1 ? sec_len - 1 : 1));
+        end
         // By default the burst length is SlinkBurstBytes
         burst_len = SlinkBurstBytes;
         // Cut the burst length if it exceeds the remaining section length

--- a/target/sim/src/vip_cheshire_soc.sv
+++ b/target/sim/src/vip_cheshire_soc.sv
@@ -799,33 +799,6 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
     input axi_pkg::size_t size,
     ref axi_data_t        beats [$]
   );
-    int size_bytes = (1 << size);
-    addr_t addr_incr = addr;
-    int i = 0;
-    int beats_left_in_page, remaining_beats, beats_to_send;
-    if (beats.size() == 0)
-      $fatal(1, "[SLINK] Zero-length write requested!");
-
-    while (i < beats.size()) begin
-      axi_data_t beats_split [$];
-      beats_left_in_page = (4096 - (addr_incr % 4096)) / size_bytes;
-      remaining_beats = beats.size() - i;
-      beats_to_send = (remaining_beats > beats_left_in_page) ? beats_left_in_page : remaining_beats;
-      for (int j = 0; j < beats_to_send; j++) begin
-        beats_split.push_back(beats[i+j]);
-      end
-      slink_write_burst(addr_incr, size, beats_split);
-      addr_incr += size_bytes * beats_to_send;
-      i += beats_to_send;
-    end
-    if (SlinkAxiDebug) $display("[SLINK] - Done");
-  endtask
-
-  task automatic slink_write_burst(
-    input addr_t          addr,
-    input axi_pkg::size_t size,
-    ref axi_data_t        beats [$]
-  );
     slink_axi_driver_t::ax_beat_t ax = new();
     slink_axi_driver_t::w_beat_t w = new();
     slink_axi_driver_t::b_beat_t b;
@@ -856,6 +829,7 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
     slink_axi_driver.recv_b(b);
     if (b.b_resp != axi_pkg::RESP_OKAY)
       $error("[SLINK] - Write error response: %d!", b.b_resp);
+    if (SlinkAxiDebug) $display("[SLINK] - Done");
   endtask
 
   task automatic slink_read_beats(

--- a/target/sim/src/vip_cheshire_soc.sv
+++ b/target/sim/src/vip_cheshire_soc.sv
@@ -884,7 +884,7 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
 
   // Load a binary
   task automatic slink_elf_preload(input string binary, output doub_bt entry);
-    longint sec_addr, sec_len, remain, page_left;
+    longint sec_addr, sec_len, remain, page_left, offset;
     $display("[SLINK] Preloading ELF binary: %s", binary);
     if (read_elf(binary))
       $fatal(1, "[SLINK] Failed to load ELF!");
@@ -893,7 +893,8 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
       $display("[SLINK] Preloading section at 0x%h (%0d bytes)", sec_addr, sec_len);
       if (read_section(sec_addr, bf, sec_len)) $fatal(1, "[SLINK] Failed to read ELF section!");
       // Write section in bursts ≤ SlinkBurstBytes that never cross a 4 KiB page
-      for (longint offset = 0; offset < sec_len; ) begin
+      offset = 0;
+      while (offset < sec_len) begin
         int burst_len, bus_offset;
         axi_data_t beats[$];
         addr_t  addr_cur  = sec_addr + offset;


### PR DESCRIPTION
The `vip_cheshire_soc`  module currently allows bursts that are larger than the allowed 4kB in AXI, which triggers some assertions in the `AXI_BUS` interface. The triggered assertions don't really impact functionality, but makes it harder in the CI to check for errors.

I had this problem in picobello, when I preload snitch binaries, which can be quite large (because they contain the entire runtime at the moment).

I only adapted it for writes at the moment, since I don't have a way to test it for large read bursts.