### PR TITLE
deps: Update `axi_rt` to newest version

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -44,8 +44,8 @@ packages:
     - common_cells
     - common_verification
   axi_rt:
-    revision: 641ea950e24722af747033f2ab85f0e48ea8d7f8
-    version: 0.0.0-alpha.9
+    revision: 50153a346b753dc2bc7723c446656a43db35d02d
+    version: 0.0.0-alpha.10
     source:
       Git: https://github.com/pulp-platform/axi_rt.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -16,7 +16,7 @@ dependencies:
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                    version: 0.39.6 }
   axi_llc:                  { git: "https://github.com/pulp-platform/axi_llc.git",                version: 0.2.1  }
   axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.8.2  }
-  axi_rt:                   { git: "https://github.com/pulp-platform/axi_rt.git",                 version: 0.0.0-alpha.9 }
+  axi_rt:                   { git: "https://github.com/pulp-platform/axi_rt.git",                 version: 0.0.0-alpha.10 }
   axi_vga:                  { git: "https://github.com/pulp-platform/axi_vga.git",                version: 0.1.3  }
   clic:                     { git: "https://github.com/pulp-platform/clic.git",                   version: 2.0.0  }
   clint:                    { git: "https://github.com/pulp-platform/clint.git",                  version: 0.2.0  }


### PR DESCRIPTION
Bumps the `axi_rt` dependency to fix minor environment issues (see https://github.com/pulp-platform/axi_rt/pull/22) when including `cheshire.mk` in systems.

Bender automatically bumped minor versions of other dependencies. But I could also isolate the `axi_rt` bump if desired.