### PR TITLE
ci: Upgrade setup-python to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: recursive
       -
         name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
       uses: actions/checkout@v3
     -
       name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         cache: pip

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: recursive
       -
         name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           cache: pip


### PR DESCRIPTION
v2 is broken, see https://github.com/actions/setup-python/issues/1085.