### PR TITLE
sw/lib: Keep crt0.S mstatus FS in Initial state

### DIFF
--- a/sw/lib/crt0.S
+++ b/sw/lib/crt0.S
@@ -109,9 +109,6 @@ _fp_init:
     fmv.d f30, f0
     fmv.d f31, f0
 
-    // Set FS state to "Clean"
-    csrrc x0, mstatus, t1
-
     // Full fence, then jump to main
     fence
     call main


### PR DESCRIPTION
As of now, the `fs` field in `mstatus` is set and cleared. The two-bit `fs` field transitions from `Off` (`0b00`) to `Initial` (`0b01`) and ends up again in `Off`, despite the comment assuming it is set to `Clean` (`0b10`).

If a workload attempts to issue certain floating point operations (e.g. `fsd`) an illegal instruction is detected in the decoder due to `fs` being `Off`. Apparently, not all floating point operations are subject to this check in the CVA6 decoder. I triggered this problem when dealing with a floating point benchmark where floating point registers had to be pushed and popped from the stack.

The immediate proposed fix would be to leave the `fs` state set to `Initial`.

See Issue https://github.com/pulp-platform/cheshire/issues/202.