### PR TITLE
target/sim: Fix `-permissive` flag in `vsim` start script

### DIFF
--- a/target/sim/vsim/start.cheshire_soc.tcl
+++ b/target/sim/vsim/start.cheshire_soc.tcl
@@ -24,10 +24,10 @@ if { ![info exists CXX_PATH] } {
 # Set voptargs only if not already set to make overridable.
 # Default on fast simulation flags.
 if { ![info exists VOPTARGS] } {
-    set VOPTARGS "-O5 +acc=p+tb_cheshire_soc. +noacc=p+cheshire_soc. +acc=r+stream_xbar"
+    set VOPTARGS "-O5 +acc=p+tb_cheshire_soc. +noacc=p+cheshire_soc. +acc=r+stream_xbar -permissive"
 }
 
-set flags "-permissive -suppress 3009 -suppress 8386 -error 7 -cpppath ${CXX_PATH} "
+set flags "-suppress 3009 -suppress 8386 -error 7 -cpppath ${CXX_PATH} "
 if { [info exists SELCFG] } { append flags "-GSelectedCfg=${SELCFG} " }
 
 set pargs ""


### PR DESCRIPTION
Current version pass this flag outside `-voptargs`, which results in warning:

```bash
# ** Warning: (vsim-12025) The -permissive option will not be passed to vopt.
# To pass this option to vopt, run with -voptargs="-permissive".
```

Moving this flag to `VOPTARGS` variable fixes this warning.