### PR TITLE
Use simulation UART to speedup printf runtime.

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -49,6 +49,7 @@ sources:
     files:
       - target/sim/models/s25fs512s.v
       - target/sim/models/24FC1025.v
+      - target/sim/src/chs_sim_uart.sv
       - target/sim/src/vip_cheshire_soc.sv
       - target/sim/src/tb_cheshire_pkg.sv
       - target/sim/src/fixture_cheshire_soc.sv

--- a/sw/lib/dif/uart.c
+++ b/sw/lib/dif/uart.c
@@ -5,6 +5,8 @@
 // Nils Wistoff <nwistoff@iis.ee.ethz.ch>
 // Paul Scheffler <paulsc@iis.ee.ethz.ch>
 
+#include "regs/cheshire.h"
+#include "dif/clint.h"
 #include "dif/uart.h"
 #include "util.h"
 #include "params.h"
@@ -66,6 +68,7 @@ void uart_read_str(void *uart_base, void *dst, uint64_t len) {
 // Default UART provides console
 void _putchar(char byte) {
     uart_write(&__base_uart, byte);
+    uart_write_flush(&__base_uart);
 }
 
 char _getchar() {

--- a/sw/tests/axirt_hello.spm.c
+++ b/sw/tests/axirt_hello.spm.c
@@ -15,6 +15,7 @@
 #include "regs/axi_rt.h"
 #include "params.h"
 #include "util.h"
+#include "printf.h"
 
 int main(void) {
     // Immediately return an error if AXI_REALM, DMA, or UART are not present
@@ -24,10 +25,6 @@ int main(void) {
 
     // This test requires at least two subordinate regions
     CHECK_ASSERT(-4, AXI_RT_PARAM_NUM_SUB >= 2);
-
-    char str[] = "Hello AXI-RT!\r\n";
-    uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
-    uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
 
     // Enable and configure AXI REALM
     __axirt_claim(1, 1);
@@ -53,9 +50,6 @@ int main(void) {
     // Enable RT unit for DMA and CVA6 core 0
     __axirt_enable(0x5);
 
-    // Configure UART and write message
-    uart_init(&__base_uart, reset_freq, __BOOT_BAUDRATE);
-    uart_write_str(&__base_uart, str, sizeof(str) - 1);
-    uart_write_flush(&__base_uart);
+    printf("Hello AXI-RT!\r\n");
     return 0;
 }

--- a/sw/tests/helloworld.c
+++ b/sw/tests/helloworld.c
@@ -11,9 +11,13 @@
 #include "dif/uart.h"
 #include "params.h"
 #include "util.h"
-#include "printf.h"
 
 int main(void) {
-    printf("Hello World!\r\n");
+    char str[] = "Hello World!\r\n";
+    uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
+    uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
+    uart_init(&__base_uart, reset_freq, __BOOT_BAUDRATE);
+    uart_write_str(&__base_uart, str, sizeof(str) - 1);
+    uart_write_flush(&__base_uart);
     return 0;
 }

--- a/sw/tests/helloworld.c
+++ b/sw/tests/helloworld.c
@@ -11,13 +11,9 @@
 #include "dif/uart.h"
 #include "params.h"
 #include "util.h"
+#include "printf.h"
 
 int main(void) {
-    char str[] = "Hello World!\r\n";
-    uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
-    uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
-    uart_init(&__base_uart, reset_freq, __BOOT_BAUDRATE);
-    uart_write_str(&__base_uart, str, sizeof(str) - 1);
-    uart_write_flush(&__base_uart);
+    printf("Hello World!\r\n");
     return 0;
 }

--- a/target/sim/src/chs_sim_uart.sv
+++ b/target/sim/src/chs_sim_uart.sv
@@ -1,0 +1,186 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Simulation UART (not synthesizable). Leverages CVA6 Mock UART.
+
+module chs_sim_uart #(
+  parameter type reg_req_t,
+  parameter type reg_rsp_t
+)(
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  reg_req_t reg_req_i,
+  output reg_rsp_t reg_rsp_o
+);
+
+  typedef struct packed {
+    logic [31:0] paddr;
+    logic [ 2:0] pprot;
+    logic        psel;
+    logic        penable;
+    logic        pwrite;
+    logic [31:0] pwdata;
+    logic [3:0]  pstrb;
+  } apb_req_t;
+
+  typedef struct packed {
+    logic pready;
+    logic [31:0] prdata;
+    logic pslverr;
+  } apb_rsp_t;
+
+  apb_req_t  apb_uart_req;
+  apb_rsp_t apb_uart_rsp;
+
+  reg_to_apb #(
+    .reg_req_t (reg_req_t),
+    .reg_rsp_t (reg_rsp_t),
+    .apb_req_t (apb_req_t),
+    .apb_rsp_t (apb_rsp_t)
+  ) i_reg_to_apb (
+    .clk_i,
+    .rst_ni,
+    .reg_req_i,
+    .reg_rsp_o,
+    .apb_req_o (apb_uart_req),
+    .apb_rsp_i (apb_uart_rsp)
+  );
+
+  chs_mock_uart i_mock_uart (
+    .clk_i,
+    .rst_ni,
+    .penable_i ( apb_uart_req.penable ),
+    .pwrite_i  ( apb_uart_req.pwrite  ),
+    .paddr_i   ( apb_uart_req.paddr   ),
+    .psel_i    ( apb_uart_req.psel    ),
+    .pwdata_i  ( apb_uart_req.pwdata  ),
+    .prdata_o  ( apb_uart_rsp.prdata  ),
+    .pready_o  ( apb_uart_rsp.pready  ),
+    .pslverr_o ( apb_uart_rsp.pslverr )
+  );
+
+endmodule : chs_sim_uart
+
+module chs_mock_uart (
+  input  logic          clk_i,
+  input  logic          rst_ni,
+  input  logic          penable_i,
+  input  logic          pwrite_i,
+  input  logic [31:0]   paddr_i,
+  input  logic          psel_i,
+  input  logic [31:0]   pwdata_i,
+  output logic [31:0]   prdata_o,
+  output logic          pready_o,
+  output logic          pslverr_o
+);
+  localparam RBR = 0;
+  localparam THR = 0;
+  localparam IER = 1;
+  localparam IIR = 2;
+  localparam FCR = 2;
+  localparam LCR = 3;
+  localparam MCR = 4;
+  localparam LSR = 5;
+  localparam MSR = 6;
+  localparam SCR = 7;
+  localparam DLL = 0;
+  localparam DLM = 1;
+
+  localparam THRE = 5; // transmit holding register empty
+  localparam TEMT = 6; // transmit holding register empty
+
+  byte lcr;
+  byte dlm;
+  byte dll;
+  byte mcr;
+  byte lsr;
+  byte ier;
+  byte msr;
+  byte scr;
+  logic fifo_enabled;
+  logic start;
+
+  assign pready_o = 1'b1;
+  assign pslverr_o = 1'b0;
+
+  function void uart_tx(logic start, byte ch);
+      if (start) $write("[UART] ");
+      $write("%c", ch);
+  endfunction : uart_tx
+
+/* verilator lint_off WIDTHTRUNC */
+/* verilator lint_off WIDTHEXPAND */
+/* verilator lint_off WIDTHCONCAT */
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      lcr <= 0;
+      dlm <= 0;
+      dll <= 0;
+      mcr <= 0;
+      lsr <= 0;
+      ier <= 0;
+      msr <= 0;
+      scr <= 0;
+      fifo_enabled <= 1'b0;
+      start <= 1'b1;
+    end else begin
+      if (psel_i & penable_i & pwrite_i) begin
+        case ((paddr_i >> 'h2) & 'h7)
+          THR: begin
+            if (lcr & 'h80) dll <= byte'(pwdata_i[7:0]);
+            else begin
+              uart_tx(start, byte'(pwdata_i[7:0]));
+              if (start) start <= 1'b0;
+            end
+          end
+          IER: begin
+            if (lcr & 'h80) dlm <= byte'(pwdata_i[7:0]);
+            else ier <= byte'(pwdata_i[7:0] & 'hF);
+          end
+          FCR: begin
+            if (pwdata_i[0]) fifo_enabled <= 1'b1;
+            else fifo_enabled <= 1'b0;
+          end
+          LCR: lcr <= byte'(pwdata_i[7:0]);
+          MCR: mcr <= byte'(pwdata_i[7:0] & 'h1F);
+          LSR: lsr <= byte'(pwdata_i[7:0]);
+          MSR: msr <= byte'(pwdata_i[7:0]);
+          SCR: scr <= byte'(pwdata_i[7:0]);
+          default:;
+        endcase
+      end
+    end
+  end
+
+  always_comb begin
+    prdata_o = '0;
+    if (psel_i & penable_i & ~pwrite_i) begin
+      case ((paddr_i >> 'h2) & 'h7)
+        THR: begin
+          if (lcr & 'h80) prdata_o = {24'b0, dll};
+        end
+        IER: begin
+          if (lcr & 'h80) prdata_o = {24'b0, dlm};
+          else prdata_o = {24'b0, ier};
+        end
+        IIR: begin
+          if (fifo_enabled) prdata_o = {24'b0, 8'hc0};
+          else prdata_o = {24'b0, 8'b0};
+        end
+        LCR: prdata_o = {24'b0, lcr};
+        MCR: prdata_o = {24'b0, mcr};
+        LSR: prdata_o = {24'b0, (lsr | (1 << THRE) | (1 << TEMT))};
+        MSR: prdata_o = {24'b0, msr};
+        SCR: prdata_o = {24'b0, scr};
+        default:;
+      endcase
+    end
+  end
+
+/* verilator lint_on WIDTHTRUNC */
+/* verilator lint_on WIDTHEXPAND */
+/* verilator lint_on WIDTHCONCAT */
+
+endmodule: chs_mock_uart

--- a/target/sim/src/fixture_cheshire_soc.sv
+++ b/target/sim/src/fixture_cheshire_soc.sv
@@ -8,8 +8,9 @@
 
 module fixture_cheshire_soc #(
   /// The selected simulation configuration from the `tb_cheshire_pkg`.
-  parameter int unsigned SelectedCfg = 32'd0,
-  parameter bit          UseDramSys  = 1'b0
+  parameter int unsigned SelectedCfg  = 32'd0,
+  parameter bit          UseDramSys   = 1'b0,
+  parameter bit          UartPrelMode = 1'b0
 );
 
   `include "cheshire/typedef.svh"
@@ -66,6 +67,7 @@ module fixture_cheshire_soc #(
   cheshire_soc #(
     .Cfg                ( DutCfg ),
     .ExtHartinfo        ( '0 ),
+    .UartPrelMode       ( UartPrelMode  ),
     .axi_ext_llc_req_t  ( axi_llc_req_t ),
     .axi_ext_llc_rsp_t  ( axi_llc_rsp_t ),
     .axi_ext_mst_req_t  ( axi_mst_req_t ),

--- a/target/sim/src/tb_cheshire_soc.sv
+++ b/target/sim/src/tb_cheshire_soc.sv
@@ -7,13 +7,15 @@
 
 module tb_cheshire_soc #(
   /// The selected simulation configuration from the `tb_cheshire_pkg`.
-  parameter int unsigned SelectedCfg = 32'd0,
-  parameter bit          UseDramSys  = 1'b0
+  parameter int unsigned SelectedCfg  = 32'd0,
+  parameter bit          UseDramSys   = 1'b0,
+  parameter bit          UartPrelMode = 1'b0
 );
 
   fixture_cheshire_soc #(
     .SelectedCfg  (SelectedCfg),
-    .UseDramSys   (UseDramSys)
+    .UseDramSys   (UseDramSys),
+    .UartPrelMode (UartPrelMode)
   ) fix();
 
   string      preload_elf;

--- a/target/sim/vcs/start.cheshire_soc.sh
+++ b/target/sim/vcs/start.cheshire_soc.sh
@@ -33,6 +33,9 @@ flags+="-cpp ${CXX_PATH} "
 pargs=""
 [[ -n "${BOOTMODE}" ]] && pargs+="+BOOTMODE=${BOOTMODE} "
 [[ -n "${PRELMODE}" ]] && pargs+="+PRELMODE=${PRELMODE} "
+if [[ "${PRELMODE}" == "2" ]]; then
+    flags+="-pvalue+UartPrelMode=1 "
+fi
 [[ -n "${BINARY}" ]]   && pargs+="+BINARY=${BINARY} "
 [[ -n "${IMAGE}" ]]    && pargs+="+IMAGE=${IMAGE} "
 

--- a/target/sim/vsim/start.cheshire_soc.tcl
+++ b/target/sim/vsim/start.cheshire_soc.tcl
@@ -32,7 +32,10 @@ if { [info exists SELCFG] } { append flags "-GSelectedCfg=${SELCFG} " }
 
 set pargs ""
 if { [info exists BOOTMODE] } { append pargs "+BOOTMODE=${BOOTMODE} " }
-if { [info exists PRELMODE] } { append pargs "+PRELMODE=${PRELMODE} " }
+if { [info exists PRELMODE] } {
+    append pargs "+PRELMODE=${PRELMODE} "
+    if { $PRELMODE == 2 } { append flags "-GUartPrelMode=1 " }
+}
 if { [info exists BINARY] } { append pargs "+BINARY=${BINARY} " }
 if { [info exists IMAGE] } { append pargs "+IMAGE=${IMAGE} " }
 


### PR DESCRIPTION
This PR addresses #46 integrating a simulation UART based on the CVA6's `mock_uart` to speedup simulation runtime during printf execution.
Currently, it makes use of the `TARGET_SIM` define to make sure the real UART is istantiated out of simulation. It also uses an additional `UartPrelMode` parameter activated if the `PRELMODE == 2`, so that also simulations that need to functionally verify UART for booting the SoC can still use the real IP. I am conscious that this is not super clean but I could not think of a better way make it. If you have in mind any cleaner solution I will be happy to discuss it :)