### PR TITLE
target/sim:  Support non-POSIX systems in `elfloader.cpp`

### DIFF
--- a/target/sim/src/elfloader.cpp
+++ b/target/sim/src/elfloader.cpp
@@ -11,16 +11,18 @@
 #include <svdpi.h>
 #include <cstring>
 #include <string>
-#ifdef _WIN32
-#include <windows.h>
-#include <cassert>
-#include <fstream>
-#else
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+// If known POSIX system, use POSIX features
+#define ELFLOADER_POSIX
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <assert.h>
 #include <unistd.h>
+#else
+// Otherwise, stick to portable C++
+#include <cassert>
+#include <fstream>
 #endif
 #include <stdlib.h>
 #include <stdio.h>
@@ -296,7 +298,7 @@ static void load_elf(char *buf, size_t size)
   }
 }
 
-#ifndef _WIN32
+#ifdef ELFLOADER_POSIX
 extern "C" char read_elf(const char *filename)
 {
   char *buf = NULL;
@@ -359,7 +361,7 @@ exit:
   return retval;
 }
 #else
-// Instead of mmap implementation for linux, windows implementation relies on
+// Instead of mmap implementation for POSIX, generic implementation relies on
 // reading elf into the buffer, which fill be passed into load_elf.
 extern "C" char read_elf(const char *filename) {
 


### PR DESCRIPTION
This PR enables running the simulation on Windows.

Although it's possible to install all the required dependencies for Cheshire on Windows, the current Makefiles do not provide a way to build the project on Windows directly. Instead, one can use WSL or build on a Linux server and copy the result to a Windows machine. After that, the paths in:

- `target/sim/vsim/compile.cheshire_soc.tcl`,
- `target/sim/vsim/start.cheshire_soc.tcl`

needs to be updated. Once this is done, the simulator can simply be launched and used according to the documentation.

I understand that using Windows in a corporate environment is uncommon, but this approach can be used by enthusiasts and students with an academic license.

If you’d like, I can write instructions for running the simulation on Windows after compiling the software using WSL.