### PR TITLE
treewide: Update CVA6 to `pulp-v2` and add vCLIC support

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -71,8 +71,8 @@ packages:
     - common_cells
     - register_interface
   clic:
-    revision: 8ed76ffc779a435d0ed034f3068e4c3334fe2ecf
-    version: 2.0.0
+    revision: 6515a71eb4ae3b143ab912d265e79832b3179a76
+    version: 3.0.0
     source:
       Git: https://github.com/pulp-platform/clic.git
     dependencies:
@@ -101,7 +101,7 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cva6:
-    revision: 9338c2ca7cf1a47aef54322f89ce867825c3c8d5
+    revision: 4c02b24fe7c04690f626776a92274da24f80d1da
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6.git
@@ -118,7 +118,7 @@ packages:
     dependencies:
     - axi
   fpnew:
-    revision: f231041c610f270ffc03cbdac38739ddb6426572
+    revision: e5aa6a01b5bbe1675c3aa8872e1203413ded83d1
     version: null
     source:
       Git: https://github.com/pulp-platform/cvfpu.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,11 +18,11 @@ dependencies:
   axi_riscv_atomics:        { git: "https://github.com/pulp-platform/axi_riscv_atomics.git",      version: 0.8.2  }
   axi_rt:                   { git: "https://github.com/pulp-platform/axi_rt.git",                 version: 0.0.0-alpha.10 }
   axi_vga:                  { git: "https://github.com/pulp-platform/axi_vga.git",                version: 0.1.3  }
-  clic:                     { git: "https://github.com/pulp-platform/clic.git",                   version: 2.0.0  }
+  clic:                     { git: "https://github.com/pulp-platform/clic.git",                   version: 3.0.0  }
   clint:                    { git: "https://github.com/pulp-platform/clint.git",                  version: 0.2.0  }
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",           version: 1.38.0 }
   common_verification:      { git: "https://github.com/pulp-platform/common_verification.git",    version: 0.2.3  }
-  cva6:                     { git: "https://github.com/pulp-platform/cva6.git",                   rev: pulp-v1.0.0 }
+  cva6:                     { git: "https://github.com/pulp-platform/cva6.git",                   rev: pulp-v2.0.0 }
   iDMA:                     { git: "https://github.com/pulp-platform/iDMA.git",                   version: 0.6.4  }
   irq_router:               { git: "https://github.com/pulp-platform/irq_router.git",             version: 0.0.1-beta.1 }
   opentitan_peripherals:    { git: "https://github.com/pulp-platform/opentitan_peripherals.git",  version: 0.4.0  }

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -63,7 +63,7 @@ chs-clean-deps:
 ######################
 
 CHS_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:pulp-restricted/cheshire-nonfree.git
-CHS_NONFREE_COMMIT ?= 1e80dbc
+CHS_NONFREE_COMMIT ?= b04738a
 
 CHS_PHONY += chs-nonfree-init
 chs-nonfree-init:

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -16,7 +16,7 @@ VLOG_ARGS   ?= -suppress 2583 -suppress 13314 -timescale 1ns/1ps
 VLOGAN_ARGS ?= -kdb -nc -assert svaext +v2k -timescale=1ns/1ps
 
 # Common Bender flags for Cheshire RTL
-CHS_BENDER_RTL_FLAGS ?= -t rtl -t cva6 -t cv64a6_imafdcsclic_sv39
+CHS_BENDER_RTL_FLAGS ?= -t rtl -t cva6 -t cv64a6_imafdchsclic_sv39_wb
 
 # Define used paths (prefixed to avoid name conflicts)
 CHS_ROOT      ?= $(shell $(BENDER) path cheshire)

--- a/docs/um/arch.md
+++ b/docs/um/arch.md
@@ -189,6 +189,15 @@ Cheshire provides both a core-local interruptor (CLINT), grouping all per-core i
 
 Finally, the PLIC and grouped CLINT also support allocating external harts for which to manage interrupts (`NumExtIrqHarts`), i.e. harts without interrupt controllers of themselves.
 
+When the CLIC is enabled, Cheshire optionally supports the [vCLIC](https://ieeexplore.ieee.org/document/10817928) extension, which can delegate interrupts to virtual machines (VMs) in hardware. This extension exposes the following parameters:
+
+| Parameter           | Type / Range | Description                                            |
+| ------------------- | ------------ | ------------------------------------------------------ |
+| `ClicVsclic`        | `bit`        | Enable delegation of interrupts to VMs                 |
+| `ClicNumVsctxts`    | `byte_bt`    | Number of supported virtual interrupt contexts         |
+| `ClicVsprio`        | `bit`        | Enable per-context priorities for virtual interrupts   |
+| `ClicPrioWidth`     | `aw_bt`      | Bit width of per-context priorities                    |
+
 ### Debug Module
 
 Cheshire provides a RISC-V-compliant [Debug Module](https://github.com/pulp-platform/riscv-dbg) with JTAG transport. It supports debugging both internal and external harts as well as system bus access (SBA). It exposes the following parameters:

--- a/hw/cheshire_pkg.sv
+++ b/hw/cheshire_pkg.sv
@@ -196,6 +196,11 @@ package cheshire_pkg;
     aw_bt   AxiRtNumAddrRegions;
     bit     AxiRtCutPaths;
     bit     AxiRtEnableChecks;
+    // Parameters for CLIC
+    bit     ClicVsclic;
+    bit     ClicVsprio;
+    byte_bt ClicNumVsctxts;
+    aw_bt   ClicPrioWidth;
   } cheshire_cfg_t;
 
   //////////////////
@@ -480,74 +485,45 @@ package cheshire_pkg;
     endcase
   endfunction
 
-  function automatic config_pkg::cva6_cfg_t gen_cva6_cfg(cheshire_cfg_t cfg);
+  function automatic config_pkg::cva6_user_cfg_t gen_cva6_cfg(cheshire_cfg_t cfg);
     doub_bt SizeSpm = get_llc_size(cfg);
     doub_bt SizeLlcOut = cfg.LlcOutRegionEnd - cfg.LlcOutRegionStart;
     doub_bt CieBase   = cfg.Cva6ExtCieOnTop ? 64'h8000_0000 - cfg.Cva6ExtCieLength : 64'h2000_0000;
     doub_bt NoCieBase = cfg.Cva6ExtCieOnTop ? 64'h2000_0000 : 64'h2000_0000 + cfg.Cva6ExtCieLength;
-    return config_pkg::cva6_cfg_t'{
-      NrCommitPorts         : 2,
-      AxiAddrWidth          : cfg.AddrWidth,
-      AxiDataWidth          : cfg.AxiDataWidth,
-      AxiIdWidth            : Cva6IdWidth,
-      AxiUserWidth          : cfg.AxiUserWidth,
-      NrLoadBufEntries      : 2,
-      FpuEn                 : 1,
-      XF16                  : 0,
-      XF16ALT               : 0,
-      XF8                   : 0,
-      XF8ALT                : 0,
-      RVA                   : 1,
-      RVB                   : 0,
-      RVV                   : 0,
-      RVC                   : 1,
-      RVH                   : 1,
-      RVZCB                 : 1,
-      XFVec                 : 0,
-      CvxifEn               : 0,
-      ZiCondExtEn           : 1,
-      RVSCLIC               : cfg.Clic,
-      RVF                   : 1,
-      RVD                   : 1,
-      FpPresent             : 1,
-      NSX                   : 0,
-      FLen                  : 64,
-      RVFVec                : 0,
-      XF16Vec               : 0,
-      XF16ALTVec            : 0,
-      XF8Vec                : 0,
-      NrRgprPorts           : 0,
-      NrWbPorts             : 0,
-      EnableAccelerator     : 0,
-      RVS                   : 1,
-      RVU                   : 1,
-      HaltAddress           : 'h800, // Relative to AmDbg
-      ExceptionAddress      : 'h810, // Relative to AmDbg
-      RASDepth              : cfg.Cva6RASDepth,
-      BTBEntries            : cfg.Cva6BTBEntries,
-      BHTEntries            : cfg.Cva6BHTEntries,
-      DmBaseAddress         : AmDbg,
-      TvalEn                : 1,
-      NrPMPEntries          : cfg.Cva6NrPMPEntries,
-      PMPCfgRstVal          : {16{64'h0}},
-      PMPAddrRstVal         : {16{64'h0}},
-      PMPEntryReadOnly      : 16'd0,
-      NOCType               : config_pkg::NOC_TYPE_AXI4_ATOP,
-      CLICNumInterruptSrc   : NumCoreIrqs + NumIntIntrs + cfg.NumExtClicIntrs,
-      NrNonIdempotentRules  : 2,   // Periphs, ExtNonCIE
-      NonIdempotentAddrBase : {64'h0000_0000, NoCieBase},
-      NonIdempotentLength   : {64'h1000_0000, 64'h6000_0000 - cfg.Cva6ExtCieLength},
-      NrExecuteRegionRules  : 6,   // Debug, Bootrom, SPM, SPM Uncached, LLCOut, ExtCIE
-      ExecuteRegionAddrBase : {AmDbg,     AmBrom,    AmSpm,   AmSpmUnc, cfg.LlcOutRegionStart, CieBase},
-      ExecuteRegionLength   : {64'h40000, 64'h40000, SizeSpm, SizeSpm,  SizeLlcOut,            cfg.Cva6ExtCieLength},
-      NrCachedRegionRules   : 3,   // CachedSPM, LLCOut, ExtCIE
-      CachedRegionAddrBase  : {AmSpm,   cfg.LlcOutRegionStart,  CieBase},
-      CachedRegionLength    : {SizeSpm, SizeLlcOut,             cfg.Cva6ExtCieLength},
-      MaxOutstandingStores  : 7,
-      DebugEn               : 1,
-      NonIdemPotenceEn      : 0,
-      AxiBurstWriteEn       : 0
-    };
+    // Base our config on the upstream default for this variant
+    config_pkg::cva6_user_cfg_t ret = cva6_config_pkg::cva6_cfg;
+    // Modify what we need to
+    ret.AxiAddrWidth          = cfg.AddrWidth;
+    ret.AxiDataWidth          = cfg.AxiDataWidth;
+    ret.AxiIdWidth            = Cva6IdWidth;
+    ret.AxiUserWidth          = cfg.AxiUserWidth;
+    ret.CvxifEn               = 0;
+    ret.DmBaseAddress         = AmDbg;
+    ret.HaltAddress           = 'h800; // Relative to AmDbg
+    ret.ExceptionAddress      = 'h810; // Relative to AmDbg
+    ret.NrNonIdempotentRules  = 2;   // Periphs, ExtNonCI;
+    ret.NonIdempotentAddrBase = {64'h0000_0000, NoCieBase};
+    ret.NOCType               = config_pkg::NOC_TYPE_AXI4_ATOP;
+    ret.NonIdempotentLength   = {64'h1000_0000, 64'h6000_0000 - cfg.Cva6ExtCieLength};
+    ret.NrExecuteRegionRules  = 6;   // Debug, Bootrom, SPM, SPM Uncached, LLCOut, ExtCI;
+    ret.ExecuteRegionAddrBase = {AmDbg,     AmBrom,    AmSpm,   AmSpmUnc, cfg.LlcOutRegionStart, CieBase};
+    ret.ExecuteRegionLength   = {64'h40000, 64'h40000, SizeSpm, SizeSpm,  SizeLlcOut,            cfg.Cva6ExtCieLength};
+    ret.NrCachedRegionRules   = 3;   // CachedSPM, LLCOut, ExtCI;
+    ret.CachedRegionAddrBase  = {AmSpm,   cfg.LlcOutRegionStart,  CieBase};
+    ret.CachedRegionLength    = {SizeSpm, SizeLlcOut,             cfg.Cva6ExtCieLength};
+    ret.DebugEn               = 1;
+    ret.RVSCLIC               = cfg.Clic;
+    ret.RVXHCLIC              = cfg.ClicVsclic;
+    ret.CLICNumInterruptSrc   = NumCoreIrqs + NumIntIntrs + cfg.NumExtClicIntrs;
+    // TODO: Should some things be removed from the main config?
+    // TODO: Should other things be added to the main config?
+    // TODO: Tune missing parameters of interest (esp. cache and interconnect) properly
+    ret.RASDepth              = cfg.Cva6RASDepth;
+    ret.BTBEntries            = cfg.Cva6BTBEntries;
+    ret.BHTEntries            = cfg.Cva6BHTEntries;
+    ret.NrPMPEntries          = cfg.Cva6NrPMPEntries;
+    // Return modified config
+    return ret;
   endfunction
 
   ////////////////
@@ -669,6 +645,11 @@ package cheshire_pkg;
     AxiRtWBufferDepth   : 16,
     AxiRtNumAddrRegions : 2,
     AxiRtCutPaths       : 1,
+    // CLIC
+    ClicVsclic        : 0,
+    ClicVsprio        : 0,
+    ClicNumVsctxts    : 4,
+    ClicPrioWidth     : 1,
     // All non-set values should be zero
     default: '0
   };

--- a/sw/tests/clic_smode.spm.S
+++ b/sw/tests/clic_smode.spm.S
@@ -1,0 +1,260 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Enrico Zelioli <ezelioli@iis.ee.ethz.ch>
+//
+// Test CLIC interrupt controller.
+//
+// Test the correct handling of interrupts when executing in different
+// privilege modes. Check the following cases:
+// - Interrupts delegated to S-mode are not taken when executing in M-mode.
+// - Interrupts delegated to S-mode are taken when executing in S-mode.
+
+#define xstr(s) str(s)
+#define str(s) s
+#define CLIC_BASE                     0x08000000
+#define CLIC_CLICCFG_REG              (CLIC_BASE + 0x0)
+#define CLIC_CLICCFG_NLBITS_OFFSET    (0)
+#define CLIC_CLICCFG_NMBITS_OFFSET    (4)
+#define CLIC_CLICINT_REG(id)          (CLIC_BASE + 0x1000 + 0x4 * id)
+#define CLIC_CLICINT_IP_OFFSET        (0)
+#define CLIC_CLICINT_IP_MASK          (1)
+#define CLIC_CLICINT_IE_OFFSET        (8)
+#define CLIC_CLICINT_IE_MASK          (1)
+#define CLIC_CLICINT_ATTR_SHV_OFFSET  (16)
+#define CLIC_CLICINT_ATTR_SHV_MASK    (1)
+#define CLIC_CLICINT_ATTR_TRIG_OFFSET (17)
+#define CLIC_CLICINT_ATTR_TRIG_MASK   (0x3)
+#define CLIC_CLICINT_ATTR_MODE_OFFSET (22)
+#define CLIC_CLICINT_ATTR_MODE_MASK   (0x3)
+#define CLIC_CLICINT_CTL_OFFSET       (24)
+#define CLIC_CLICINT_CTL_MASK         (0xff)
+
+#define MINTTHRESH                    (0x347)
+#define MTVT                          (0x307)
+
+#define TEST_IRQ_LINE                 (31)
+
+#define SMODE                         (1)
+#define MMODE                         (3)
+
+#define WAIT(N) \
+  li a0, (N); \
+  jal wait
+
+// Wait task: perform busy loop.
+// Number of iterations is passed in a0.
+wait:
+  mv   t0, a0
+1:
+  addi t0, t0, -1
+  bnez t0, 1b
+
+  ret
+
+// Enable an interrupt line on the CLIC.
+// Interrupt line number is passed in a0.
+// Interrupt privilege mode is passed in a1.
+enable_interrupt:
+
+  // Compute interrupt's clicint base address
+  mv   s2, a0
+  slli s2, s2, 2
+  li   s1, CLIC_CLICINT_REG(0)
+  add  s2, s2, s1
+
+  // Set trigger type to edge-triggered
+  mv   t0, s2
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_ATTR_TRIG_OFFSET
+  or   t1, t1, t2
+  // Set privilege mode
+  li   t2, CLIC_CLICINT_ATTR_MODE_MASK
+  slli t2, t2, CLIC_CLICINT_ATTR_MODE_OFFSET
+  not  t2, t2
+  and  t1, t1, t2
+  slli t2, a1, CLIC_CLICINT_ATTR_MODE_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  // Set interrupt level and priority
+  mv   t0, s2
+  lw   t1, 0(t0)
+  li   t2, 0xaa << CLIC_CLICINT_CTL_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  // Enable interrupt
+  mv   t0, s2
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_IE_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  ret
+
+// Trigger an interrupt line on the CLIC.
+// Interrupt line number is passed in a0.
+trigger_interrupt:
+
+  // Compute interrupt's clicint base address
+  mv   s2, a0
+  slli s2, s2, 2
+  li   s1, CLIC_CLICINT_REG(0)
+  add  s2, s2, s1
+
+  // Trigger interrupt via SW
+  mv   t0, s2
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_IP_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  ret
+
+// Restore mtvec and return 0 (PASS)
+pass_restore:
+  csrw mtvec, s0
+  li a0, 0
+  j exit
+
+// Restore mtvec and return 1 (FAIL)
+fail_restore:
+  csrw mtvec, s0
+  li a0, 1
+  j exit
+
+// Enviroment call to M-mode. By default,
+// return value is passed in a0. Return PASS.
+smode_pass:
+  li a0, 0
+  ecall
+
+// Enviroment call to M-mode. By default,
+// return value is passed in a0. Return FAIL.
+smode_fail:
+  li a0, 1
+  ecall
+
+// Return to runtime environment.
+// Return address was saved in mscratch
+exit:
+  csrr ra, mscratch
+  ret
+
+.align
+.option norvc
+.global main
+main:
+
+  // Save return address
+  csrw mscratch, ra
+
+  // Enable interrupts (set mstatus.mie)
+  csrsi mstatus, 0x8
+
+  // Activate CLIC mode
+  la t0, mtvec_handler_fail
+  ori t0, t0, 0x3
+  csrrw s0, mtvec, t0
+
+  // CLIC configuration
+  // Set number of bits for level and privilege mode encoding
+  li   t0, CLIC_CLICCFG_REG
+  li   t1, 0x4 << CLIC_CLICCFG_NLBITS_OFFSET
+  li   t2, 0x3 << CLIC_CLICCFG_NMBITS_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  // Set interrupt threshold to zero
+  li   a0, 0x1
+  csrw MINTTHRESH, zero
+
+  /////////////////////////////////////
+  //              Test 1             //
+  /////////////////////////////////////
+  // Delegate interrupt line to S-mode and
+  // check that it does not trigger while
+  // executing in M-mode
+  li  a0, TEST_IRQ_LINE
+  li  a1, SMODE
+  jal enable_interrupt
+  WAIT(500)
+  li  a0, TEST_IRQ_LINE
+  jal trigger_interrupt
+  WAIT(500)
+
+  /////////////////////////////////////
+  //              Test 2             //
+  /////////////////////////////////////
+  // Jump to S-mode and check that the same
+  // interrupt when triggered is taken
+
+  // mret will jump to the address in mepc
+  la   t0, smode_entry
+  csrw mepc, t0
+  // Set mstatus.MPP to 01 (S-mode)
+  li   t0, 0x800
+  csrs mstatus, t0
+  mret
+
+  j fail_restore
+
+
+// S-mode entry point.
+// Set up interrupt handler and enable interrupts.
+// Interrupt was set pending already and should
+// trigger immediately after interrupts are enabled.
+smode_entry:
+
+  // Write interrupt handler
+  la    t0, stvec_handler_succeed
+  ori   t0, t0, 0x3
+  csrrw s0, stvec, t0
+
+  // Enable interrupts (set sstatus.sie)
+  csrsi sstatus, 0x2
+
+  WAIT(100)
+
+  // Should not reach here
+  j smode_fail
+
+
+// Check return value from S-mode
+// (by convention stored in a0)
+// and succeed or fail accordingly.
+check_smode_return:
+  beqz a0, pass_restore
+  j fail_restore
+
+.align 8
+.global mtvec_handler_fail
+mtvec_handler_fail:
+  csrr t0, mcause
+  li   t1, 1 << 63
+  and  t0, t0, t1
+  beqz t0, check_smode_return
+  j fail_restore
+
+.align 8
+.global mtvec_handler_succeed
+mtvec_handler_succeed:
+  csrr t0, mcause
+  li   t1, 1 << 63
+  and  t0, t0, t1
+  beqz t0, check_smode_return
+  j pass_restore
+
+.align 8
+.global stvec_handler_fail
+stvec_handler_fail:
+  j smode_fail
+
+.align 8
+.global stvec_handler_succeed
+stvec_handler_succeed:
+  j smode_pass
+
+.data

--- a/sw/tests/clic_vsmode.spm.S
+++ b/sw/tests/clic_vsmode.spm.S
@@ -1,0 +1,328 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Enrico Zelioli <ezelioli@iis.ee.ethz.ch>
+//
+// Test CLIC interrupt controller.
+//
+// Test the correct handling of interrupts when executing in different
+// privilege modes. Check the following cases:
+// - Interrupts delegated to VS-mode are not taken when executing in M-mode.
+// - Interrupts delegated to VS-mode are not taken when executing in HS-mode.
+// - Interrupts delegated to VS-mode are taken when executing in VS-mode.
+
+#define xstr(s) str(s)
+#define str(s) s
+#define CLIC_BASE                     0x08000000
+#define CLIC_CLICCFG_REG              (CLIC_BASE + 0x0)
+#define CLIC_CLICCFG_NLBITS_OFFSET    (0)
+#define CLIC_CLICCFG_NMBITS_OFFSET    (4)
+#define CLIC_CLICINT_REG(id)          (CLIC_BASE + 0x1000 + 0x4 * id)
+#define CLIC_CLICINT_IP_OFFSET        (0)
+#define CLIC_CLICINT_IP_MASK          (1)
+#define CLIC_CLICINT_IE_OFFSET        (8)
+#define CLIC_CLICINT_IE_MASK          (1)
+#define CLIC_CLICINT_ATTR_SHV_OFFSET  (16)
+#define CLIC_CLICINT_ATTR_SHV_MASK    (1)
+#define CLIC_CLICINT_ATTR_TRIG_OFFSET (17)
+#define CLIC_CLICINT_ATTR_TRIG_MASK   (0x3)
+#define CLIC_CLICINT_ATTR_MODE_OFFSET (22)
+#define CLIC_CLICINT_ATTR_MODE_MASK   (0x3)
+#define CLIC_CLICINT_CTL_OFFSET       (24)
+#define CLIC_CLICINT_CTL_MASK         (0xff)
+#define CLIC_CLICINTV_REG(id)         (CLIC_BASE + 0xd000 + id)
+
+#define MINTTHRESH                    (0x347)
+#define MTVT                          (0x307)
+
+#define TEST_IRQ_LINE                 (31)
+#define TEST_VSID                     (1)
+
+#define SMODE                         (1)
+#define MMODE                         (3)
+
+#define WAIT(N) \
+  li a0, (N); \
+  jal wait
+
+// Wait task: perform busy loop.
+// Number of iterations is passed in a0.
+wait:
+  mv   t0, a0
+1:
+  addi t0, t0, -1
+  bnez t0, 1b
+
+  ret
+
+// Enable an interrupt line on the CLIC.
+// Interrupt line number is passed in a0.
+// Interrupt privilege mode is passed in a1.
+enable_interrupt:
+
+  // Compute interrupt's clicint base address
+  mv   s2, a0
+  slli s2, s2, 2
+  li   s1, CLIC_CLICINT_REG(0)
+  add  s2, s2, s1
+
+  // Set trigger type to edge-triggered
+  mv   t0, s2
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_ATTR_TRIG_OFFSET
+  or   t1, t1, t2
+  // Set privilege mode
+  li   t2, CLIC_CLICINT_ATTR_MODE_MASK
+  slli t2, t2, CLIC_CLICINT_ATTR_MODE_OFFSET
+  not  t2, t2
+  and  t1, t1, t2
+  slli t2, a1, CLIC_CLICINT_ATTR_MODE_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  // Set interrupt level and priority
+  mv   t0, s2
+  lw   t1, 0(t0)
+  li   t2, 0xaa << CLIC_CLICINT_CTL_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  // Enable interrupt
+  mv   t0, s2
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_IE_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  ret
+
+// Delegate an interrupt line on the CLIC to VS-mode.
+// Interrupt line number is passed in a0.
+// Interrupt line VSID is passed in a1.
+delegate_vs_interrupt:
+
+  // Compute interrupt's clicintv base address
+  li   t0, 0x3
+  and  t1, a0, t0 # Offset
+  not  t0, t0
+  and  s2, a0, t0 # Base address
+  li   s1, CLIC_CLICINTV_REG(0)
+  add  s2, s2, s1
+
+  // Write to clicintv register
+  slli t0, a1, 0x2
+  ori  t0, t0, 0x1
+  slli t1, t1, 3
+  sll  t0, t0, t1
+  sw   t0, (s2)
+
+  ret
+
+// Trigger an interrupt line on the CLIC.
+// Interrupt line number is passed in a0.
+trigger_interrupt:
+
+  // Compute interrupt's clicint base address
+  mv   s2, a0
+  slli s2, s2, 2
+  li   s1, CLIC_CLICINT_REG(0)
+  add  s2, s2, s1
+
+  // Trigger interrupt via SW
+  mv   t0, s2
+  lw   t1, 0(t0)
+  li   t2, 1 << CLIC_CLICINT_IP_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  ret
+
+// Restore mtvec and return 0 (PASS)
+pass_restore:
+  csrw mtvec, s0
+  li a0, 0
+  j exit
+
+// Restore mtvec and return 1 (FAIL)
+fail_restore:
+  csrw mtvec, s0
+  li a0, 1
+  j exit
+
+// Enviroment call to M-mode. By default,
+// return value is passed in a0. Return PASS.
+smode_pass:
+  li a0, 0
+  ecall
+
+// Enviroment call to M-mode. By default,
+// return value is passed in a0. Return FAIL.
+smode_fail:
+  li a0, 1
+  ecall
+
+// Return to runtime environment.
+// Return address was saved in mscratch
+exit:
+  csrr ra, mscratch
+  ret
+
+.align
+.option norvc
+.global main
+main:
+
+  // Save return address
+  csrw mscratch, ra
+
+  // Enable interrupts (set mstatus.mie)
+  csrsi mstatus, 0x8
+
+  // Activate CLIC mode
+  la t0, mtvec_handler_fail
+  ori t0, t0, 0x3
+  csrrw s0, mtvec, t0
+
+  // CLIC configuration
+  // Set number of bits for level and privilege mode encoding
+  li   t0, CLIC_CLICCFG_REG
+  li   t1, 0x4 << CLIC_CLICCFG_NLBITS_OFFSET
+  li   t2, 0x3 << CLIC_CLICCFG_NMBITS_OFFSET
+  or   t1, t1, t2
+  sw   t1, 0(t0)
+
+  // Set interrupt threshold to zero
+  li   a0, 0x1
+  csrw MINTTHRESH, zero
+
+  /////////////////////////////////////
+  //              Test 1             //
+  /////////////////////////////////////
+  // Delegate interrupt line to VS-mode and
+  // check that it does not trigger while
+  // executing in M-mode
+  li  a0, TEST_IRQ_LINE
+  li  a1, SMODE
+  jal enable_interrupt
+  li a1, 1
+  jal delegate_vs_interrupt
+  WAIT(500)
+  li  a0, TEST_IRQ_LINE
+  jal trigger_interrupt
+  WAIT(500)
+
+  /////////////////////////////////////
+  //              Test 2             //
+  /////////////////////////////////////
+  // Jump to HS-mode and check that the same
+  // interrupt does not trigger
+
+  // mret will jump to the address in mepc
+  la   t0, hsmode_entry
+  csrw mepc, t0
+  // Set mstatus.MPP to 01 (HS-mode)
+  li   t0, 0x1000
+  csrs mstatus, t0
+  mret
+
+  j fail_restore
+
+
+// HS-mode entry point.
+// Set up interrupt handler and enable interrupts.
+// Interrupt was set pending already and should not
+// trigger even after interrupts are enabled.
+hsmode_entry:
+
+  // Write interrupt handler
+  la    t0, stvec_handler_fail
+  ori   t0, t0, 0x3
+  csrrw s0, stvec, t0
+
+  // Enable interrupts (set sstatus.sie)
+  csrsi sstatus, 0x2
+
+  // Wait some time to make sure no interrupt
+  // is bein triggered.
+  WAIT(10)
+
+  /////////////////////////////////////
+  //              Test 3             //
+  /////////////////////////////////////
+  // Jump to VS-mode and check that the same
+  // interrupt when triggered is taken
+
+  // sret will jump to the address in mepc
+  la   t0, vsmode_entry
+  csrw sepc, t0
+  // Set sstatus.SPP to 1 (HS/VS-mode)
+  li   t0, 0x100
+  csrs sstatus, t0
+  // Set hstatus.SPV to 1 (VS-mode) and
+  // set hstatus.VGEIN to TEST_VSID
+  li   t0, 0x80
+  li   t1, TEST_VSID << 12
+  or   t0, t0, t1
+  csrs hstatus, t0
+  sret
+
+  // Should not reach here
+  j smode_fail
+
+// VS-mode entry point.
+// Set up interrupt handler and enable interrupts.
+// Interrupt was set pending already and should
+// trigger immediately after interrupts are enabled.
+vsmode_entry:
+
+  // Write interrupt handler
+  la    t0, stvec_handler_succeed
+  ori   t0, t0, 0x3
+  csrrw s0, stvec, t0
+
+  // Enable interrupts (set sstatus.sie)
+  csrsi sstatus, 0x2
+
+  WAIT(100)
+
+  // Should not reach here
+  j smode_fail
+
+
+// Check return value from S-mode
+// (by convention stored in a0)
+// and succeed or fail accordingly.
+check_smode_return:
+  beqz a0, pass_restore
+  j fail_restore
+
+.align 8
+.global mtvec_handler_fail
+mtvec_handler_fail:
+  csrr t0, mcause
+  li   t1, 1 << 63
+  and  t0, t0, t1
+  beqz t0, check_smode_return
+  j fail_restore
+
+.align 8
+.global mtvec_handler_succeed
+mtvec_handler_succeed:
+  csrr t0, mcause
+  li   t1, 1 << 63
+  and  t0, t0, t1
+  beqz t0, check_smode_return
+  j pass_restore
+
+.align 8
+.global stvec_handler_fail
+stvec_handler_fail:
+  j smode_fail
+
+.align 8
+.global stvec_handler_succeed
+stvec_handler_succeed:
+  j smode_pass
+
+.data

--- a/target/sim/src/tb_cheshire_pkg.sv
+++ b/target/sim/src/tb_cheshire_pkg.sv
@@ -23,14 +23,26 @@ package tb_cheshire_pkg;
       return ret;
     endfunction
 
+    // A dedicated vCLIC config
+    function automatic cheshire_cfg_t gen_cheshire_vclic_cfg();
+      cheshire_cfg_t ret = DefaultCfg;
+      ret.Clic = 1;
+      ret.ClicVsclic = 1;
+      ret.ClicVsprio = 1;
+      ret.ClicNumVsctxts = 4;
+      ret.ClicPrioWidth = 1;
+      return ret;
+    endfunction
+
     // Number of Cheshire configurations
-    localparam int unsigned NumCheshireConfigs = 32'd3;
+    localparam int unsigned NumCheshireConfigs = 32'd4;
 
     // Assemble a configuration array indexed by a numeric parameter
     localparam cheshire_cfg_t [NumCheshireConfigs-1:0] TbCheshireConfigs = {
-        gen_cheshire_clic_cfg(), // 2: CLIC-enabled configuration
-        gen_cheshire_rt_cfg(),   // 1: RT-enabled configuration
-        DefaultCfg               // 0: Default configuration
+        gen_cheshire_vclic_cfg(), // 3: vCLIC-enabled configuration
+        gen_cheshire_clic_cfg(),  // 2: CLIC-enabled configuration
+        gen_cheshire_rt_cfg(),    // 1: RT-enabled configuration
+        DefaultCfg                // 0: Default configuration
     };
 
 endpackage

--- a/target/xilinx/src/cheshire_top_xilinx.sv
+++ b/target/xilinx/src/cheshire_top_xilinx.sv
@@ -125,6 +125,13 @@ module cheshire_top_xilinx import cheshire_pkg::*; (
     ret.RegExtRegionStart [0] = 32'h4300_0000;
     ret.RegExtRegionEnd   [0] = 32'h4300_1000;
   `endif
+  `ifdef USE_VCLIC
+    ret.Clic = 1;
+    ret.ClicVsclic = 1;
+    ret.ClicVsprio = 1;
+    ret.ClicNumVsctxts = 4;
+    ret.ClicPrioWidth = 1;
+  `endif
     return ret;
   endfunction
 


### PR DESCRIPTION
~Maintainer Note: This PR is *stalled* waiting for the following:~
~* Formal release of `v3.0.0` of `clic` (stakeholder: @ezelioli)~

TODO:

* [x] Replace CLIC with release v3.0.0
* [x] Add new CLIC parameters to doc