### PR TITLE
target/sim: Clarify 64b alignment for `jtag_elf_preload`

### DIFF
--- a/target/sim/src/vip_cheshire_soc.sv
+++ b/target/sim/src/vip_cheshire_soc.sv
@@ -324,6 +324,7 @@ module vip_cheshire_soc import cheshire_pkg::*; #(
   endtask
 
   // Load a binary
+  // Note: all sections must be 64b-aligned
   task automatic jtag_elf_preload(input string binary, output doub_bt entry);
     longint sec_addr, sec_len;
     $display("[JTAG] Preloading ELF binary: %s", binary);


### PR DESCRIPTION
Very minimal commit adding a comment to the `jtag_elf_preload` function, mentioning the requirement that ELF sections be 64b aligned. Preloading otherwise fails with a system bus error, originating from a misaligned access by the DM (`sberror`=3).

As an example where this caused trouble, this function was used in Picobello to preload Snitch's binary, in which sections are 32b-aligned.

Perhaps on a more general note, we could promote the functions in `vip_cheshire_soc` which do not depend on Cheshire (e.g. `jtag_elf_preload`) to `riscv-dbg`, where this function could be extended to support different section alignments. Error messages could also be extended to mention the exact system bus error cause. Let me know if you deem this useful, I could open a PR implementing this.