### PR TITLE
Adopt actively mantained fork of `printf` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "sw/deps/printf"]
 	path = sw/deps/printf
-	url = https://github.com/mpaland/printf
+	url = https://github.com/eyalroz/printf
 	ignore = dirty
 [submodule "sw/deps/cva6-sdk"]
 	path = sw/deps/cva6-sdk

--- a/sw/boot/flash.c
+++ b/sw/boot/flash.c
@@ -18,7 +18,7 @@
 #include "hal/spi_sdcard.h"
 #include "hal/uart_debug.h"
 #include "gpt.h"
-#include "printf.h"
+#include "printf/printf.h"
 
 int flash_spi_sdcard(uint64_t core_freq, uint64_t rtc_freq, void *img_base, uint64_t sector,
                      uint64_t len) {

--- a/sw/boot/flash.c
+++ b/sw/boot/flash.c
@@ -68,8 +68,8 @@ int main() {
     uint64_t sector = scratch[2];
     uint64_t len = scratch[3];
     // Flash chosen disk
-    printf("[FLASH] Write buffer at 0x%x of length %d to target %d, sector %d ... ", img_base, len,
-           target, sector);
+    printf("[FLASH] Write buffer at 0x%p of length %ld to target %ld, sector %ld ... ", img_base,
+           len, target, sector);
     switch (target) {
     case 1: {
         ret = flash_spi_sdcard(core_freq, rtc_freq, img_base, sector, len);

--- a/sw/boot/zsl.c
+++ b/sw/boot/zsl.c
@@ -13,7 +13,7 @@
 #include "dif/clint.h"
 #include "gpt.h"
 #include "dif/uart.h"
-#include "printf.h"
+#include "printf/printf.h"
 
 // Type for firmware payload
 typedef int (*payload_t)(uint64_t, uint64_t, uint64_t);

--- a/sw/boot/zsl.c
+++ b/sw/boot/zsl.c
@@ -39,14 +39,14 @@ static inline void load_part_or_spin(void *priv, const uint64_t *pguid, void *co
     else if (part_idx < 0)
         printf("[ZSL] No %s", name);
     else {
-        printf("[ZSL] Copy %s (part %d, LBA %d-%d) to 0x%lx... ", name, part_idx, lba_begin,
+        printf("[ZSL] Copy %s (part %ld, LBA %ld-%ld) to 0x%p... ", name, part_idx, lba_begin,
                lba_end, dst);
         grread(priv, dst, 0x200 * lba_begin, 0x200 * (lba_end - lba_begin + 1));
         printf("OK\r\n");
         return;
     }
     // Catch
-    printf(" with at most %d sectors and type GUID 0x%llx%llx", max_lbas, pguid[1], pguid[0]);
+    printf(" with at most %ld sectors and type GUID 0x%lx%lx", max_lbas, pguid[1], pguid[0]);
     while (1) wfi();
 }
 
@@ -65,13 +65,13 @@ int main(void) {
     // Print boot-critical cat, and also parameters
     printf(" /\\___/\\       Boot mode:       %d\r\n"
            "( o   o )      Real-time clock: %d Hz\r\n"
-           "(  =^=  )      System clock:    %d Hz\r\n"
-           "(        )     Read global ptr: 0x%08x\r\n"
-           "(    P    )    Read pointer:    0x%08x\r\n"
-           "(  U # L   )   Read argument:   0x%08x\r\n"
+           "(  =^=  )      System clock:    %ld Hz\r\n"
+           "(        )     Read global ptr: 0x%p\r\n"
+           "(    P    )    Read pointer:    0x%p\r\n"
+           "(  U # L   )   Read argument:   0x%p\r\n"
            "(    P      )\r\n"
            "(           ))))))))))\r\n\r\n",
-           bootmode, rtc_freq, core_freq, rgp, read, priv);
+           bootmode, rtc_freq, core_freq, rgp, (void *)(uintptr_t)read, priv);
 
     // If this is a GPT disk boot, load payload and device tree
     if (read & 1) {
@@ -82,7 +82,8 @@ int main(void) {
 
     // Launch payload
     payload_t fw = __BOOT_ZSL_FW;
-    printf("[ZSL] Launch firmware at %lx with device tree at %lx\r\n", fw, __BOOT_ZSL_DTB);
+    printf("[ZSL] Launch firmware at %p with device tree at %p\r\n", (void *)(uintptr_t)fw,
+           __BOOT_ZSL_DTB);
     fencei();
     return fw(0, (uintptr_t)__BOOT_ZSL_DTB, 0);
 }
@@ -94,8 +95,8 @@ void trap_vector() {
                  "csrr %3, mie; csrr %4, mstatus; csrr %5, mtval"
                  : "=r"(mcause), "=r"(mepc), "=r"(mip), "=r"(mie), "=r"(mstatus), "=r"(mtval));
     printf("\r\n==== [ZSL] trap encountered ====\r\n"
-           " mcause:     0x%016x\r\n mepc:       0x%016x\r\n mip:        0x%016x\r\n"
-           " mie:        0x%016x\r\n mstatus:    0x%016x\r\n mtval:      0x%016x\r\n"
+           " mcause:     0x%016lx\r\n mepc:       0x%016lx\r\n mip:        0x%016lx\r\n"
+           " mie:        0x%016lx\r\n mstatus:    0x%016lx\r\n mtval:      0x%016lx\r\n"
            "================================\r\n",
            mcause, mepc, mip, mie, mstatus, mtval);
     while (1) wfi();

--- a/sw/include/dif/uart.h
+++ b/sw/include/dif/uart.h
@@ -45,3 +45,8 @@ void uart_read_str(void *uart_base, void *dst, uint64_t len);
 void _putchar(char byte);
 
 char _getchar();
+
+// `printf` standalone implementation
+void putchar_(char byte);
+
+char getchar_();

--- a/sw/lib/dif/uart.c
+++ b/sw/lib/dif/uart.c
@@ -71,3 +71,12 @@ void _putchar(char byte) {
 char _getchar() {
     return uart_read(&__base_uart);
 }
+
+// `printf` standalone implementation
+void putchar_(char byte) {
+    uart_write(&__base_uart, byte);
+}
+
+char getchar_() {
+    return uart_read(&__base_uart);
+}

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -23,7 +23,7 @@ CHS_SW_DTB_TGUID := BA442F61-2AEF-42DE-9233-E4D75D3ACB9D
 CHS_SW_FW_TGUID  := 99EC86DA-3F5B-4B0D-8F4B-C4BACFA5F859
 CHS_SW_DISK_SIZE ?= 16M
 
-CHS_SW_FLAGS   ?= -DOT_PLATFORM_RV32 -march=rv64gc_zifencei -mabi=lp64d -mstrict-align -O2 -Wall -Wextra -static -ffunction-sections -fdata-sections -frandom-seed=cheshire -fuse-linker-plugin -flto -Wl,-flto
+CHS_SW_FLAGS   ?= -DOT_PLATFORM_RV32 -DPRINTF_ALIAS_STANDARD_FUNCTION_NAMES_HARD=1 -march=rv64gc_zifencei -mabi=lp64d -mstrict-align -O2 -Wall -Wextra -static -ffunction-sections -fdata-sections -frandom-seed=cheshire -fuse-linker-plugin -flto -Wl,-flto
 CHS_SW_CCFLAGS ?= $(CHS_SW_FLAGS) -ggdb -mcmodel=medany -mexplicit-relocs -fno-builtin -fverbose-asm -pipe
 CHS_SW_LDFLAGS ?= $(CHS_SW_FLAGS) -nostartfiles -Wl,--gc-sections -Wl,-L$(CHS_SW_LD_DIR)
 CHS_SW_ARFLAGS ?= --plugin=$(CHS_SW_LTOPLUG)
@@ -36,12 +36,12 @@ CHS_SW_ALL += $(CHS_SW_LIBS) $(CHS_SW_GEN_HDRS) $(CHS_SW_TESTS) $(CHS_SW_TOOLS)
 # Dependencies #
 ################
 
-CHS_SW_DEPS_INCS  = -I$(CHS_SW_DIR)/deps/printf
+CHS_SW_DEPS_INCS  = -I$(CHS_SW_DIR)/deps/printf/src
 CHS_SW_DEPS_INCS += -I$(CHS_LLC_DIR)/sw/include
 CHS_SW_DEPS_INCS += -I$(AXIRTROOT)/sw/lib
 CHS_SW_DEPS_INCS += -I$(OTPROOT)
 CHS_SW_DEPS_INCS += -I$(OTPROOT)/sw/include
-CHS_SW_DEPS_SRCS  = $(CHS_SW_DIR)/deps/printf/printf.c
+CHS_SW_DEPS_SRCS  = $(CHS_SW_DIR)/deps/printf/src/printf/printf.c
 CHS_SW_DEPS_SRCS += $(CHS_LLC_DIR)/sw/lib/axi_llc_reg32.c
 CHS_SW_DEPS_SRCS += $(AXIRTROOT)/sw/lib/axirt.c
 CHS_SW_DEPS_SRCS += $(wildcard $(OTPROOT)/sw/device/lib/base/*.c)


### PR DESCRIPTION
I have noticed that the current submodule of `printf` points to a repository which is no longer mantained (see https://github.com/mpaland/printf/issues/128). Instead, a fork of it is currently the most up-to-date version available (see https://github.com/eyalroz/printf). Since I needed some specific format specifiers to run selected benchmarks of Cheshire which were better supported in the currently mantained fork, I went through the changes needed to switch to the new submodule.

Some observations:

- The new submodule requires an additional compilation define (```PRINTF_ALIAS_STANDARD_FUNCTION_NAMES_HARD```)
- The header to be included is now ```printf/printf.h```
- Several format specifiers resulted in warnings due to data types mismatches. I should have fixed them.

If you believe it makes sense to adopt it generally, we can iterate on this PR.