### PR TITLE
hw: Support custom `axi_xbar` config structs

### DIFF
--- a/hw/cheshire_soc.sv
+++ b/hw/cheshire_soc.sv
@@ -241,6 +241,8 @@ module cheshire_soc import cheshire_pkg::*; #(
     AxiAddrWidth:       Cfg.AddrWidth,
     AxiDataWidth:       Cfg.AxiDataWidth,
     NoAddrRules:        AxiOut.num_rules,
+    // Setting a `default` here allows for custom XBars with extended configs outside Cheshire.
+    // Importantly, this requires that '0 *disables* any and all such custom extensions.
     default: '0
   };
 


### PR DESCRIPTION
In picobello we have the issue that the clusters use a multicast capable AXI xbar that have additional fields in the `xbar_cfg_t`. We don't actually want to use a multicast capable AXI xbar in Cheshire, but since we cannot have two separate  `axi` dependencies in a project, our workaround was to assign `default: '0` to unknown struct fields, which should be compatible with the vanilla AXI xbar

There is a PR open to merge the multicast capable AXI xbar https://github.com/pulp-platform/axi/pull/398, but it is unlikely to make progress anytime soon, since it is a major change and also probably not entirely AXI compliant. Hence, this change would allow us to again track the main branch of cheshire and make it easier to stay up to date new developments (e.g. the SystemRDL ones https://github.com/pulp-platform/cheshire/pull/253 https://github.com/pulp-platform/cheshire/pull/252).

It's not the best solution and if you disagree with this change, we will keep a `picobello` branch on cheshire and I will close this PR again.