### PR TITLE
fix: resolve questa fatal crash when simulating with DRAMSys

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -111,8 +111,8 @@ packages:
     - fpnew
     - tech_cells_generic
   dram_rtl_sim:
-    revision: 2cac4a9e12a60537567276b539ab6c919c87b5dc
-    version: 0.1.1
+    revision: 5d298cc685cde32f3c1ed815a35ac7087c58f547
+    version: null
     source:
       Git: https://github.com/pulp-platform/dram_rtl_sim.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -112,7 +112,7 @@ packages:
     - tech_cells_generic
   dram_rtl_sim:
     revision: a764d5200a19cdd72a5237cbfb16985515a3058d
-    version: null
+    version: 0.1.2
     source:
       Git: https://github.com/pulp-platform/dram_rtl_sim.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -111,7 +111,7 @@ packages:
     - fpnew
     - tech_cells_generic
   dram_rtl_sim:
-    revision: 5d298cc685cde32f3c1ed815a35ac7087c58f547
+    revision: a764d5200a19cdd72a5237cbfb16985515a3058d
     version: null
     source:
       Git: https://github.com/pulp-platform/dram_rtl_sim.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -31,7 +31,7 @@ dependencies:
   riscv-dbg:                { git: "https://github.com/pulp-platform/riscv-dbg.git",              version: 0.8.1  }
   serial_link:              { git: "https://github.com/pulp-platform/serial_link.git",            version: 2.0.0  }
   unbent:                   { git: "https://github.com/pulp-platform/unbent.git",                 version: 0.1.6  }
-  dram_rtl_sim:             { git: "https://github.com/pulp-platform/dram_rtl_sim.git",           version: 0.1.1  }
+  dram_rtl_sim:             { git: "https://github.com/pulp-platform/dram_rtl_sim.git",           rev: sm/chs-fix  }
 
 export_include_dirs:
   - hw/include

--- a/Bender.yml
+++ b/Bender.yml
@@ -31,7 +31,7 @@ dependencies:
   riscv-dbg:                { git: "https://github.com/pulp-platform/riscv-dbg.git",              version: 0.8.1  }
   serial_link:              { git: "https://github.com/pulp-platform/serial_link.git",            version: 2.0.0  }
   unbent:                   { git: "https://github.com/pulp-platform/unbent.git",                 version: 0.1.6  }
-  dram_rtl_sim:             { git: "https://github.com/pulp-platform/dram_rtl_sim.git",           rev: sm/chs-fix  }
+  dram_rtl_sim:             { git: "https://github.com/pulp-platform/dram_rtl_sim.git",           rev: main  }
 
 export_include_dirs:
   - hw/include

--- a/Bender.yml
+++ b/Bender.yml
@@ -31,7 +31,7 @@ dependencies:
   riscv-dbg:                { git: "https://github.com/pulp-platform/riscv-dbg.git",              version: 0.8.1  }
   serial_link:              { git: "https://github.com/pulp-platform/serial_link.git",            version: 2.0.0  }
   unbent:                   { git: "https://github.com/pulp-platform/unbent.git",                 version: 0.1.6  }
-  dram_rtl_sim:             { git: "https://github.com/pulp-platform/dram_rtl_sim.git",           rev: main  }
+  dram_rtl_sim:             { git: "https://github.com/pulp-platform/dram_rtl_sim.git",           version: 0.1.2  }
 
 export_include_dirs:
   - hw/include


### PR DESCRIPTION
Simulating with DRAMSys (`set USE_DRAMSYS 1`) currently crashes with fatal error. Fixed by updating the `dram_rtl_sim` dependency to pull in the commit that links stdc++fs, which resolves a SIGSEGV on GCC 8.