### PR TITLE
clang-format: add top level `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+IndentWidth: 4
+ColumnLimit: 100
+AlignEscapedNewlines: DontAlign
+SortIncludes: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,16 +57,6 @@ jobs:
       with:
         extensions: 'c,h,cpp'
         clangFormatVersion: 14
-        style: >
-          {
-          IndentWidth: 4,
-          ColumnLimit: 100,
-          AlignEscapedNewlines: DontAlign,
-          SortIncludes: false,
-          AllowShortFunctionsOnASingleLine: None,
-          AllowShortIfStatementsOnASingleLine: true,
-          AllowShortLoopsOnASingleLine: true
-          }
         exclude: |
           ./sw/include/regs/*.h
           ./target/sim/src/elfloader.cpp


### PR DESCRIPTION
Add a top level `.clang-format` file to have a unified source of truth for the expected style. This should make possible invoking `clang-format` without additional options to quickly ensure the code is compliant with the linter.