### PR TITLE
feat: Build dtb with bitstream

### DIFF
--- a/cheshire.mk
+++ b/cheshire.mk
@@ -34,6 +34,7 @@ DRAM_RTL_SIM_ROOT := $(shell $(BENDER) path dram_rtl_sim)
 
 REGTOOL ?= $(CHS_REG_DIR)/vendor/lowrisc_opentitan/util/regtool.py
 PEAKRDL ?= peakrdl
+MAKO    ?= mako-render
 
 
 ################

--- a/sw/boot/cheshire.dtsi.mako
+++ b/sw/boot/cheshire.dtsi.mako
@@ -31,24 +31,26 @@
     #address-cells = <1>;
     #size-cells = <0>;
     timebase-frequency = <1000000>; // 1 MHz
-    CPU0: cpu@0 {
+% for i in range(int(num_cores)):
+    CPU${i}: cpu@${i} {
       device_type = "cpu";
       status = "okay";
       compatible = "eth,ariane", "riscv";
       clock-frequency = <50000000>; // 50 MHz
-      riscv,isa = "rv64imafdc";
+      riscv,isa = "${riscv_isa}";
       mmu-type = "riscv,sv39";
       tlb-split;
-      reg = <0>;
-      CPU0_intc: interrupt-controller {
+      reg = <${i}>;
+      CPU${i}_intc: interrupt-controller {
         #address-cells = <0>;
         #interrupt-cells = <1>;
         interrupt-controller;
         compatible = "riscv,cpu-intc";
       };
     };
+% endfor
   };
-
+<%text>
   soc: soc {
     #address-cells = <2>;
     #size-cells = <2>;
@@ -100,7 +102,9 @@
     };
     clint@2040000 {
       compatible = "riscv,clint0";
-      interrupts-extended = <&CPU0_intc 3 &CPU0_intc 7>;
+</%text>
+      interrupts-extended = ${'<' + ' '.join(f'&CPU{i}_intc 3 &CPU{i}_intc 7' for i in range(int(num_cores))) + '>'};
+<%text>
       reg-names = "control";
       reg = <0x0 0x2040000 0x0 0x040000>;
     };
@@ -109,7 +113,9 @@
       #address-cells = <0>;
       #interrupt-cells = <1>;
       interrupt-controller;
-      interrupts-extended = <&CPU0_intc 11 &CPU0_intc 9>;
+</%text>
+      interrupts-extended = ${'<' + ' '.join(f'&CPU{i}_intc 11 &CPU{i}_intc 9' for i in range(int(num_cores))) + '>'};
+<%text>
       riscv,max-priority = <7>;
       riscv,ndev = <51>;
       reg = <0x0 0x4000000 0x0 0x4000000>;
@@ -117,3 +123,4 @@
   };
 
 };
+</%text>

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -159,8 +159,9 @@ $(foreach link,$(CHS_SW_LINK_MODES),$(eval $(call chs_sw_ld_elf_rule,$(link))))
 # Images from CVA6 SDK (built externally)
 CHS_CVA6_SDK_IMGS ?= $(addprefix $(CHS_SW_DIR)/deps/cva6-sdk/install64/,fw_payload.bin uImage)
 
-# Create full Linux disk image
-$(CHS_SW_DIR)/boot/linux.%.gpt.bin: $(CHS_SW_DIR)/boot/zsl.rom.bin $(CHS_SW_DIR)/boot/cheshire.%.dtb $(CHS_CVA6_SDK_IMGS)
+# Create full Linux disk image (DTB from FPGA flow: target/xilinx/out/cheshire.%.dtb)
+$(CHS_SW_DIR)/boot/linux.%.gpt.bin: $(CHS_SW_DIR)/boot/zsl.rom.bin \
+		$(CHS_ROOT)/target/xilinx/out/cheshire.%.dtb $(CHS_CVA6_SDK_IMGS)
 	truncate -s $(CHS_SW_DISK_SIZE) $@
 	sgdisk --clear -g --set-alignment=1 \
 		--new=1:64:96 --typecode=1:$(CHS_SW_ZSL_TGUID) \

--- a/target/xilinx/xilinx.mk
+++ b/target/xilinx/xilinx.mk
@@ -47,12 +47,56 @@ $(CHS_XILINX_DIR)/build/%/out.xci: \
 # Bitstreams #
 ##############
 
+ifneq ($(filter chs-xilinx-%,$(MAKECMDGOALS)),)
+# Generate cheshire.dtsi from its Mako template when add_sources or HW config changes
+$(CHS_XILINX_DIR)/build/%.dtb/cheshire.dtsi: \
+		$(CHS_SW_DIR)/boot/cheshire.dtsi.mako \
+		$(CHS_XILINX_DIR)/scripts/add_sources.%.tcl
+	@mkdir -p $(dir $@)
+	@# Find cva6 config from Bender script, then extract CMO enable from CVA6 config package
+	@# Extract number of cores from Cheshire config package
+	@# TODO: Use slang to extract all these after elaboration
+	@add_sources_tcl="$(CHS_XILINX_DIR)/scripts/add_sources.$*.tcl"; \
+	cva6_config_pkg=$$(grep -Po '\.bender/.*/cv[a-zA-Z0-9_-]*_config_pkg\.sv' "$$add_sources_tcl"); \
+	num_cores=$$(grep -Po 'NumCores *: *\K[0-9]+' $(CHS_ROOT)/hw/cheshire_pkg.sv); \
+	zicbom_en=$$(sed -n "s/.*RVZiCbom: bit'(\([0-9]\+\)).*/\1/p" "$$cva6_config_pkg"); \
+	riscv_isa="rv64imafdc"; \
+	[[ "$$zicbom_en" -eq 1 ]] && riscv_isa+="_zicbom"; \
+	$(MAKO) --var riscv_isa="$$riscv_isa" --var num_cores="$$num_cores" $< > $@
+.PRECIOUS: $(CHS_XILINX_DIR)/build/%.dtb/cheshire.dtsi
+else
+$(CHS_XILINX_DIR)/build/%.dtb/cheshire.dtsi:
+	@echo "A device-tree should be built with a bitstream to be synched"
+	@exit 1
+endif
+
+# Create a device-tree binary synched with the CVA6 configuration (CHS_BENDER_RTL_FLAGS) at
+# the time of bitstream generation. We stage all the device tree sources under out/.dtb/<board>/
+# and compiled the DTB from there.
+ifneq ($(filter chs-xilinx-%,$(MAKECMDGOALS)),)
+$(CHS_XILINX_DIR)/out/cheshire.%.dtb: \
+		$(CHS_SW_DIR)/boot/cheshire.%.dts \
+		$(wildcard $(CHS_SW_DIR)/boot/*.dtsi) \
+		$(CHS_XILINX_DIR)/build/%.dtb/cheshire.dtsi
+	@mkdir -p $(dir $@)
+	@# Stage the device tree sources from sw/boot dir (apart from generated fragments)
+	cp -f $(filter-out %cheshire.dtsi, $^) $(CHS_XILINX_DIR)/build/$*.dtb/
+	@# Compile the DTB
+	$(CHS_SW_DTC) -I dts -O dtb -o $@ -i $(CHS_XILINX_DIR)/build/$*.dtb/ $<
+else
+$(CHS_XILINX_DIR)/out/cheshire.%.dtb:
+	@echo "A device-tree should be built with a bitstream to be synched"
+	@exit 1
+endif
+.PRECIOUS: $(CHS_XILINX_DIR)/out/cheshire.%.dtb
+
 CHS_XILINX_BOARDS := genesys2 vcu128 vcu118
 
 CHS_XILINX_IPS_genesys2 := clkwiz vio mig7s
 CHS_XILINX_IPS_vcu128   := clkwiz vio ddr4
 CHS_XILINX_IPS_vcu118   := clkwiz vio ddr4
 
+# Bender Vivado source script synched with CHS_BENDER_RTL_FLAGS
 $(CHS_XILINX_DIR)/scripts/add_sources.%.tcl: $(CHS_ROOT)/Bender.yml $(CHS_XILINX_HW)
 	$(BENDER) script vivado -t fpga -t $* $(CHS_BENDER_RTL_FLAGS) > $@
 
@@ -60,6 +104,7 @@ define chs_xilinx_bit_rule
 $$(CHS_XILINX_DIR)/out/%.$(1).bit: \
 		$$(CHS_XILINX_DIR)/scripts/impl_sys.tcl \
 		$$(CHS_XILINX_DIR)/scripts/add_sources.$(1).tcl \
+		$$(CHS_XILINX_DIR)/out/cheshire.$(1).dtb \
 		$$(CHS_XILINX_IPS_$(1):%=$(CHS_XILINX_DIR)/build/$(1).%/out.xci) \
 		$$(CHS_HW_ALL) \
 		| $$(CHS_XILINX_DIR)/build/$(1).%/


### PR DESCRIPTION
- Makes dtb reconfigurable with Mako (numcores and zicbom ISA)
- Build dtb with bitstream so it is synched with the Bender target