### PR TITLE
idma_wrap: Add missing submodule port

### DIFF
--- a/hw/cheshire_idma_wrap.sv
+++ b/hw/cheshire_idma_wrap.sv
@@ -140,6 +140,7 @@ module cheshire_idma_wrap #(
     .axi_rsp_o  ( axi_slv_rsp_o ),
     .reg_req_o  ( dma_reg_req ),
     .reg_rsp_i  ( dma_reg_rsp ),
+    .reg_id_o   ( ),
     .busy_o     ( )
    );
 


### PR DESCRIPTION
Add a missing output port for `axi_to_reg_v2`. Fixes a compilation warning reported in https://github.com/pulp-platform/cheshire/issues/274.