### PR TITLE
make: Separate models from `CHS_SIM_ALL`

### DIFF
--- a/cheshire.mk
+++ b/cheshire.mk
@@ -187,10 +187,10 @@ $(CHS_ROOT)/target/sim/models/24FC1025.v: $(CHS_ROOT)/Bender.yml | $(CHS_ROOT)/t
 	unzip -p 24xx1025_Verilog_Model.zip 24FC1025.v > $@
 	rm 24xx1025_Verilog_Model.zip
 
-CHS_MODELS_ALL += $(CHS_ROOT)/target/sim/models/s25fs512s.v
-CHS_MODELS_ALL += $(CHS_ROOT)/target/sim/models/24FC1025.v
+CHS_SIM_MODELS_ALL += $(CHS_ROOT)/target/sim/models/s25fs512s.v
+CHS_SIM_MODELS_ALL += $(CHS_ROOT)/target/sim/models/24FC1025.v
 
-CHS_SIM_ALL += $(CHS_MODELS_ALL)
+CHS_SIM_ALL += $(CHS_SIM_MODELS_ALL)
 CHS_SIM_ALL += $(CHS_ROOT)/target/sim/vsim/compile.cheshire_soc.tcl
 CHS_SIM_ALL += $(CHS_ROOT)/target/sim/vcs/compile.cheshire_soc.sh
 

--- a/cheshire.mk
+++ b/cheshire.mk
@@ -187,8 +187,10 @@ $(CHS_ROOT)/target/sim/models/24FC1025.v: $(CHS_ROOT)/Bender.yml | $(CHS_ROOT)/t
 	unzip -p 24xx1025_Verilog_Model.zip 24FC1025.v > $@
 	rm 24xx1025_Verilog_Model.zip
 
-CHS_SIM_ALL += $(CHS_ROOT)/target/sim/models/s25fs512s.v
-CHS_SIM_ALL += $(CHS_ROOT)/target/sim/models/24FC1025.v
+CHS_MODELS_ALL += $(CHS_ROOT)/target/sim/models/s25fs512s.v
+CHS_MODELS_ALL += $(CHS_ROOT)/target/sim/models/24FC1025.v
+
+CHS_SIM_ALL += $(CHS_MODELS_ALL)
 CHS_SIM_ALL += $(CHS_ROOT)/target/sim/vsim/compile.cheshire_soc.tcl
 CHS_SIM_ALL += $(CHS_ROOT)/target/sim/vcs/compile.cheshire_soc.sh
 


### PR DESCRIPTION
Provide a convenience variable for all simulation models. Platforms integrating Cheshire tend to have their own simulation scripts, so they don't need to build all of `CHS_SIM_ALL`, but only the models.