### PR TITLE
build(sw): derive iDMA register header from PeakRDL c-header

### DIFF
--- a/sw/include/dif/dma.h
+++ b/sw/include/dif/dma.h
@@ -8,24 +8,25 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 #include "regs/idma.h"
 #include "params.h"
 
-#define DMA_SRC_ADDR(BASE) (void *)((uint8_t *)BASE + IDMA_REG64_2D_SRC_ADDR_LOW_REG_OFFSET)
-#define DMA_DST_ADDR(BASE) (void *)((uint8_t *)BASE + IDMA_REG64_2D_DST_ADDR_LOW_REG_OFFSET)
-#define DMA_NUMBYTES_ADDR(BASE) (void *)((uint8_t *)BASE + IDMA_REG64_2D_LENGTH_LOW_REG_OFFSET)
-#define DMA_CONF_ADDR(BASE) (void *)((uint8_t *)BASE + IDMA_REG64_2D_CONF_REG_OFFSET)
-#define DMA_STATUS_ADDR(BASE) (void *)((uint8_t *)BASE + IDMA_REG64_2D_STATUS_0_REG_OFFSET)
-#define DMA_NEXTID_ADDR(BASE) (void *)((uint8_t *)BASE + IDMA_REG64_2D_NEXT_ID_0_REG_OFFSET)
-#define DMA_DONE_ADDR(BASE) (void *)((uint8_t *)BASE + IDMA_REG64_2D_DONE_ID_0_REG_OFFSET)
+#define DMA_SRC_ADDR(BASE) (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, src_addr))
+#define DMA_DST_ADDR(BASE) (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, dst_addr))
+#define DMA_NUMBYTES_ADDR(BASE) (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, length))
+#define DMA_CONF_ADDR(BASE) (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, conf))
+#define DMA_STATUS_ADDR(BASE) (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, status))
+#define DMA_NEXTID_ADDR(BASE) (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, next_id))
+#define DMA_DONE_ADDR(BASE) (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, done_id))
 #define DMA_SRC_STRIDE_ADDR(BASE) \
-    (void *)((uint8_t *)BASE + IDMA_REG64_2D_SRC_STRIDE_2_LOW_REG_OFFSET)
+    (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, dim[0].src_stride))
 #define DMA_DST_STRIDE_ADDR(BASE) \
-    (void *)((uint8_t *)BASE + IDMA_REG64_2D_DST_STRIDE_2_LOW_REG_OFFSET)
-#define DMA_NUM_REPS_ADDR(BASE) (void *)((uint8_t *)BASE + IDMA_REG64_2D_REPS_2_LOW_REG_OFFSET)
+    (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, dim[0].dst_stride))
+#define DMA_NUM_REPS_ADDR(BASE) (void *)((uint8_t *)BASE + offsetof(idma_reg64_2d_t, dim[0].reps))
 #define DMA_CONF_DECOUPLE_NONE (0)
-#define DMA_CONF_DECOUPLE_AW (1 << IDMA_REG64_2D_CONF_DECOUPLE_AW_BIT)
-#define DMA_CONF_DECOUPLE_RW (1 << IDMA_REG64_2D_CONF_DECOUPLE_RW_BIT)
+#define DMA_CONF_DECOUPLE_AW (1 << IDMA_REG64_2D__CONF__DECOUPLE_AW_bp)
+#define DMA_CONF_DECOUPLE_RW (1 << IDMA_REG64_2D__CONF__DECOUPLE_RW_bp)
 #define DMA_CONF_DECOUPLE_ALL (DMA_CONF_DECOUPLE_AW | DMA_CONF_DECOUPLE_RW)
 
 #define X(NAME, BASE_ADDR) \
@@ -83,7 +84,7 @@
         *(NAME##_dma_src_ptr()) = (uint64_t)src; \
         *(NAME##_dma_dst_ptr()) = (uint64_t)dst; \
         *(NAME##_dma_num_bytes_ptr()) = size; \
-        *(NAME##_dma_conf_ptr()) = conf | (1 << IDMA_REG64_2D_CONF_ENABLE_ND_BIT); \
+        *(NAME##_dma_conf_ptr()) = conf | (1 << IDMA_REG64_2D__CONF__ENABLE_ND_bp); \
         *(NAME##_dma_src_stride_ptr()) = src_stride; \
         *(NAME##_dma_dst_stride_ptr()) = dst_stride; \
         *(NAME##_dma_num_reps_ptr()) = num_reps; \

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -78,9 +78,19 @@ endef
 
 $(eval $(call chs_sw_gen_hdr_rule,clint,$(CLINTROOT)/src/clint.hjson $(CLINTROOT)/.generated))
 $(eval $(call chs_sw_gen_hdr_rule,axi_vga,$(AXI_VGA_ROOT)/data/axi_vga.hjson $(AXI_VGA_ROOT)/.generated))
-$(eval $(call chs_sw_gen_hdr_rule,idma,$(IDMA_ROOT)/target/rtl/idma_reg64_2d.hjson))
 $(eval $(call chs_sw_gen_hdr_rule,axi_llc,$(CHS_LLC_DIR)/data/axi_llc_regs.hjson))
 $(eval $(call chs_sw_gen_hdr_rule,axi_rt,$(AXIRTROOT)/src/regs/axi_rt.hjson $(AXIRTROOT)/.generated))
+
+# iDMA ships SystemRDL: generate its C header with PeakRDL like Cheshire's own regs
+# (params select the reg64_2d frontend instantiated by Cheshire)
+.PRECIOUS: $(CHS_SW_DIR)/include/regs/idma.h
+CHS_SW_GEN_HDRS += $(CHS_SW_DIR)/include/regs/idma.h
+
+$(CHS_SW_DIR)/include/regs/idma.h: $(IDMA_ROOT)/src/frontend/reg/idma_reg.rdl
+	@mkdir -p $(dir $@)
+	$(PEAKRDL) c-header $< -o $@ -b ltoh --type-style hier --rename idma_reg64_2d \
+	  -P SysAddrWidth=64 -P NumDims=2 -P Log2NumDims=1
+	@sed -i '1i// Copyright 2026 ETH Zurich and University of Bologna.\n// Solderpad Hardware License, Version 0.51, see LICENSE for details.\n// SPDX-License-Identifier: SHL-0.51\n' $@
 
 .PRECIOUS: $(CHS_SW_DIR)/include/regs/cheshire.h
 CHS_SW_GEN_HDRS += $(CHS_SW_DIR)/include/regs/cheshire.h


### PR DESCRIPTION
## What

Adapts Cheshire SW to iDMA's SystemRDL/PeakRDL register flow:
- `sw.mk`: drop the `regtool --cdefines` rule on the (now removed) `idma_reg64_2d.hjson`. Generate `regs/idma.h` with PeakRDL **c-header directly from iDMA's RDL source** (`$(IDMA_ROOT)/src/frontend/reg/idma_reg.rdl`), exactly like Cheshire already generates `cheshire.h` from its own RDL.
- `dma.h`: port off the regtool macro names (`*_REG_OFFSET`, `*_BIT`) to `offsetof()` on the generated `idma_reg64_2d_t` struct plus the PeakRDL bit-position macros (`*_bp`).

## Why

iDMA removed the hjson register description in its SystemRDL migration, so `regtool` can no longer generate `regs/idma.h`. Rather than copying a pre-generated header, this leverages Cheshire's existing PeakRDL flow — consistent with `cheshire.h` and the rest of the SystemRDL-based register generation.

## Verified end-to-end

Real Cheshire make + RISC-V toolchain against an RDL-era iDMA:
- `make` generates `sw/include/regs/idma.h` from iDMA's RDL (`idma_reg64_2d_t` struct + `IDMA_REG64_2D__*_bp` macros).
- `dma_1d.spm.elf`, `dma_2d.spm.elf`, `dma_slink.spm.elf` all compile **and link**.
- Register offsets match the old regtool map exactly (conf=0x0, dst_addr=0xD0, strides 0x100/0x108, reps=0x110, ND bit=10).

## Depends on / TODO before merge

- [ ] Bump the (transitive) `idma` Bender dependency to any RDL-era iDMA (post-SystemRDL; e.g. the `common-cells-v2` branch for Gwaihir). Only iDMA's RDL source is needed — no special iDMA build target.
- [ ] Regenerate the committed `sw/include/regs/idma.h` after the bump.
