### PR TITLE
fix: derive the SPM addrmap size from the LLC config

### DIFF
--- a/hw/cheshire.rdl
+++ b/hw/cheshire.rdl
@@ -24,7 +24,13 @@ addrmap periph_stub_t #(longint unsigned Size = 0x1000) {
     external reg { field {} _end[31:0]   = 0; } _end   @(Size - 4);
 };
 
-addrmap cheshire #(longint unsigned SlinkNumLanes = 4) {
+addrmap cheshire #(
+    longint unsigned SlinkNumLanes = 4,
+    longint unsigned LlcSetAssoc   = 8,
+    longint unsigned LlcNumLines   = 256,
+    longint unsigned LlcNumBlocks  = 8,
+    longint unsigned AxiDataWidth  = 64
+) {
     desc = "Cheshire SoC system address map";
 
     ////////////////////
@@ -43,9 +49,9 @@ addrmap cheshire #(longint unsigned SlinkNumLanes = 4) {
         sw = r; executable = true;
     } bootrom @0x0200_0000;
 
-    // Scratchpad memory (SPM / LLC); 64 KiB minimum, read+write+exec
+    // Scratchpad memory (SPM / LLC), read+write+exec
     external mem {
-        mementries = 16384; memwidth = 32;
+        mementries = LlcSetAssoc * LlcNumLines * LlcNumBlocks * AxiDataWidth / 8 / 4; memwidth = 32;
         sw = rw; executable = true;
     } spm @0x1000_0000;
 


### PR DESCRIPTION
The `spm` region in `cheshire.rdl` is hardcoded to `mementries = 16384` (64 KiB), but the SPM is just the LLC used as a scratchpad, so its real size is `get_llc_size(cfg)`, which is 128 KiB for `DefaultCfg`. The RTL already decodes it at that size (`gen_axi_out` uses `SizeSpm = get_llc_size`), so the RDL was only under-declaring the region to SW: the generated C headers and linker scripts report 64 KiB regardless of the LLC config.

This parameterizes the `cheshire` addrmap with the LLC geometry (`LlcSetAssoc`, `LlcNumLines`, `LlcNumBlocks`, `AxiDataWidth`, defaulting to `DefaultCfg`) and computes the `spm` size from those. With the defaults, `CHESHIRE_SPM_SIZE` goes from `0x10000` to `0x20000`.

A couple of things I left out of scope:
- The build only threads `SlinkNumLanes` into peakrdl (`CHS_PEAKRDL_PARAMS`), not the LLC params, so a non-`DefaultCfg` LLC currently needs the `-P` values passed by hand. Wiring `cfg` into `-P`, ideally from the same source `cheshire_pkg` reads (it still keeps its own copy of these), would close that.
- `spm_unc` is left as its static 64 MiB reserved window; only `spm` is parameterized here.
